### PR TITLE
fixing cellranger bug #35

### DIFF
--- a/bin/alignment/cellranger/submit.sh
+++ b/bin/alignment/cellranger/submit.sh
@@ -99,7 +99,6 @@ cellranger count \
     --sample="\$SAMPLE" \
     --localcores=$CPU \
     --localmem=$((MEM / 1000)) \
-    --output-dir="\$OUTPUT_DIR" \
     $BAM_FLAG
 EOF
 


### PR DESCRIPTION
removed --output-dir from cellranger as it is no longer needed.