### PR TITLE
Bugfix/iget fastqs iinit - Adding check if logged into irods

### DIFF
--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -47,7 +47,7 @@ def execute_command():
 
     except FileNotFoundError:
         echo_message(
-            "Command not found. Ensure the necessary tools are installed and available in your PATH.",
+            "iRODS not loaded. please run `module load cellgen/irods` before running this solosis command again.",
             "error",
         )
         sys.exit(1)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -21,6 +21,15 @@ def spinner():
             yield frame
 
 
+import subprocess
+import sys
+
+
+def echo_message(message, level="info"):
+    """Utility function to print messages with a given level."""
+    print(f"[{level.upper()}] {message}")
+
+
 def execute_command():
     """Run a command and handle specific output conditions."""
     command = [
@@ -34,20 +43,23 @@ def execute_command():
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
         )
 
-        # Check the command output (stderr in this case) for the specific message
-        if "Enter your current iRODS password:" in result.stderr:
+        # Debugging: Print the actual stderr output
+        print("DEBUG: stderr output from command:", result.stderr)
+
+        # Check for specific error message in stderr
+        if "Enter your current iRODS password" in result.stderr:
             echo_message(
-                "run `iinit` before running this solosis command again.",
+                "Run `iinit` before running this solosis command again.",
                 "error",
             )
             sys.exit(1)  # Exit with error status 1
 
-        # If no specific error output, the script can continue
-        echo_message("command executed successfully.", "success")
+        # If no error message, continue execution
+        echo_message("Command executed successfully.", "success")
 
     except FileNotFoundError:
         echo_message(
-            "command not found. ensure the iRODS are installed and available in your PATH.",
+            "Command not found. Ensure the necessary tools are installed and available in your PATH.",
             "error",
         )
         sys.exit(1)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -21,15 +21,6 @@ def spinner():
             yield frame
 
 
-import subprocess
-import sys
-
-
-def echo_message(message, level="info"):
-    """Utility function to print messages with a given level."""
-    print(f"[{level.upper()}] {message}")
-
-
 def execute_command():
     """Run a command and handle specific output conditions."""
     command = [
@@ -43,18 +34,15 @@ def execute_command():
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
         )
 
-        # Debugging: Print the actual stderr output
-        print("DEBUG: stderr output from command:", result.stderr)
-
-        # Check for specific error message in stderr
-        if "Enter your current iRODS password" in result.stderr:
+        # Check for the specific error in stderr
+        if "CAT_INVALID_AUTHENTICATION" in result.stderr:
             echo_message(
                 "Run `iinit` before running this solosis command again.",
                 "error",
             )
             sys.exit(1)  # Exit with error status 1
 
-        # If no error message, continue execution
+        # If no error, command executed successfully
         echo_message("Command executed successfully.", "success")
 
     except FileNotFoundError:

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -21,15 +21,32 @@ def spinner():
             yield frame
 
 
-# check if irods has been loaded into current environment
 def check_irods_initialized():
-    """Check if iRODS is initialized by running an `iget` command."""
-    # Remove the cached credentials
+    """Check if iRODS is initialized by running an iget command."""
+    # Path to cached iRODS credentials
     irods_auth_file = os.path.expanduser("~/.irods/.irodsA")
-    if os.path.exists(irods_auth_file):
-        os.remove(irods_auth_file)
-        echo_message(f"removed cached iRODS credentials at {irods_auth_file}", "info")
 
+    # Remove the cached credentials
+    if os.path.exists(irods_auth_file):
+        try:
+            os.remove(irods_auth_file)
+            echo_message(
+                f"removed cached iRODS credentials at {irods_auth_file}", "info"
+            )
+        except OSError as e:
+            echo_message(
+                f"Failed to remove iRODS credentials: {e.strerror}",
+                "error",
+            )
+            sys.exit(1)  # Exit with an error code
+    else:
+        echo_message(
+            f"iRODS is not loaded. please run iinit before running this command again.",
+            "error",
+        )
+        sys.exit(1)  # Exit with an error code
+
+    # Test command to check iRODS functionality
     test_command = [
         "iget",
         "/seq/illumina/runs/48/48297/cellranger/cellranger720_count_48297_58_rBCN14591738_GRCh38-2020-A/web_summary.html",
@@ -44,7 +61,7 @@ def check_irods_initialized():
         # Check for the "Enter your current iRODS password" message
         if "Enter your current iRODS password" in result.stderr:
             echo_message(
-                "iRODS is not loaded. please run `iinit` before running this command again.",
+                "iRODS is not loaded. please run iinit before running this command again.",
                 "error",
             )
             sys.exit(1)  # Exit with an error code

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -35,7 +35,7 @@ def execute_command():
         )
 
         # Check the command output (stderr in this case) for the specific message
-        if "Enter your current iRODS password" in result.stderr:
+        if "Enter your current iRODS password:" in result.stderr:
             echo_message(
                 "run `iinit` before running this solosis command again.",
                 "error",

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -34,7 +34,7 @@ def check_irods_initialized():
         except FileNotFoundError:
             # Handle edge case where 'os.remove' fails but behaves like 'rm'
             echo_message(
-                "iRODS is not loaded. please run iinit before running this command again.",
+                "iRODS is not loaded. please run `iinit` before running this command again.",
                 "error",
             )
             sys.exit(1)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -37,7 +37,7 @@ def execute_command():
         # Check for the specific error in stderr
         if "CAT_INVALID_AUTHENTICATION" in result.stderr:
             echo_message(
-                "Run `iinit` before running this solosis command again.",
+                "run `iinit` before running this solosis command again.",
                 "error",
             )
             sys.exit(1)  # Exit with error status 1
@@ -47,7 +47,7 @@ def execute_command():
 
     except FileNotFoundError:
         echo_message(
-            "iRODS not loaded. please run `module load cellgen/irods` before running this solosis command again.",
+            "iRODS not loaded. please run `module load cellgen/irods` and then `iinit` before running this solosis command again.",
             "error",
         )
         sys.exit(1)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -61,7 +61,7 @@ def check_irods_initialized():
         # Check for the "Enter your current iRODS password" message
         if "Enter your current iRODS password" in result.stderr:
             echo_message(
-                "iRODS is not loaded. please run iinit before running this command again.",
+                "iRODS is not loaded. please run `iinit` before running this command again.",
                 "error",
             )
             sys.exit(1)  # Exit with an error code

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -22,29 +22,12 @@ def spinner():
 
 
 def check_irods_initialized():
-    """Check if iRODS is initialized by running an iget command."""
+    """Check if iRODS is initialized by running an `iget` command."""
     # Remove the cached credentials
     irods_auth_file = os.path.expanduser("~/.irods/.irodsA")
     if os.path.exists(irods_auth_file):
-        try:
-            os.remove(irods_auth_file)
-            echo_message(
-                f"removed cached iRODS credentials at {irods_auth_file}", "info"
-            )
-        except FileNotFoundError:
-            # Handle edge case where 'os.remove' fails but behaves like 'rm'
-            echo_message(
-                "iRODS is not loaded. please run `iinit` before running this command again.",
-                "error",
-            )
-            sys.exit(1)
-    else:
-        # Simulate 'rm' behavior for missing files
-        echo_message(
-            "iRODS is not loaded. please run iinit before running this command again.",
-            "error",
-        )
-        sys.exit(1)
+        os.remove(irods_auth_file)
+        echo_message(f"Removed cached iRODS credentials at {irods_auth_file}", "info")
 
     test_command = [
         "iget",
@@ -60,13 +43,13 @@ def check_irods_initialized():
         # Check for the "Enter your current iRODS password" message
         if "Enter your current iRODS password" in result.stderr:
             echo_message(
-                "iRODS is not loaded. please run iinit before running this command again.",
+                "iRODS is not initialized. Please run `iinit` before running this command again.",
                 "error",
             )
             sys.exit(1)  # Exit with an error code
     except FileNotFoundError:
         echo_message(
-            "the 'iget' command was not found. ensure iRODS is installed and available in your PATH.",
+            "The 'iget' command was not found. Ensure iRODS is installed and available in your PATH.",
             "error",
         )
         sys.exit(1)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -41,7 +41,7 @@ def check_irods_initialized():
             sys.exit(1)  # Exit with an error code
     else:
         echo_message(
-            f"iRODS is not loaded. please run iinit before running this command again.",
+            f"iRODS is not loaded. please run `module load cellgen/irods` then `iinit` before running this command again.",
             "error",
         )
         sys.exit(1)  # Exit with an error code

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -23,24 +23,29 @@ def spinner():
 
 def check_irods_initialized():
     """Check if iRODS is initialized by running an iget command."""
-    # Path to cached iRODS credentials
+    # Remove the cached credentials
     irods_auth_file = os.path.expanduser("~/.irods/.irodsA")
-
-    # If credentials exist, remove them (forces re-authentication)
     if os.path.exists(irods_auth_file):
         try:
             os.remove(irods_auth_file)
             echo_message(
-                f"Removed cached iRODS credentials at {irods_auth_file}", "info"
+                f"removed cached iRODS credentials at {irods_auth_file}", "info"
             )
-        except OSError as e:
+        except FileNotFoundError:
+            # Handle edge case where 'os.remove' fails but behaves like 'rm'
             echo_message(
-                f"Failed to remove cached credentials: {e.strerror}",
+                "iRODS is not loaded. please run iinit before running this command again.",
                 "error",
             )
             sys.exit(1)
+    else:
+        # Simulate 'rm' behavior for missing files
+        echo_message(
+            "iRODS is not loaded. please run iinit before running this command again.",
+            "error",
+        )
+        sys.exit(1)
 
-    # Test command to check if iRODS is functional
     test_command = [
         "iget",
         "/seq/illumina/runs/48/48297/cellranger/cellranger720_count_48297_58_rBCN14591738_GRCh38-2020-A/web_summary.html",
@@ -52,26 +57,16 @@ def check_irods_initialized():
             test_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
         )
 
-        # Check for the "Enter your current iRODS password" message in stderr
+        # Check for the "Enter your current iRODS password" message
         if "Enter your current iRODS password" in result.stderr:
             echo_message(
-                "iRODS is not loaded. Please run `module load cellgen/irods` and then `iinit`.",
+                "iRODS is not loaded. please run iinit before running this command again.",
                 "error",
             )
-            sys.exit(1)
-        elif "CAT_NO_ACCESS" in result.stderr or "error" in result.stderr.lower():
-            echo_message(
-                "Access error. Ensure you have the correct permissions or re-run `iinit`.",
-                "error",
-            )
-            sys.exit(1)
-
-        # If no errors, assume iRODS is initialized
-        echo_message("iRODS is initialized and ready to use.", "success")
-
+            sys.exit(1)  # Exit with an error code
     except FileNotFoundError:
         echo_message(
-            "The 'iget' command was not found. Ensure iRODS is installed and available in your PATH.",
+            "the 'iget' command was not found. ensure iRODS is installed and available in your PATH.",
             "error",
         )
         sys.exit(1)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -47,7 +47,7 @@ def execute_command():
 
     except FileNotFoundError:
         echo_message(
-            "iRODS not loaded. please run `module load cellgen/irods` and then `iinit` before running this solosis command again.",
+            "iRODS not loaded. please run `module load cellgen/irods` before re-running this solosis command.",
             "error",
         )
         sys.exit(1)


### PR DESCRIPTION
Provided irods check using example irods command (`iget path/to/directory`) expecting a certain outcome, an error message and exit code can be given to prompt users to log into irods before proceeding. 

The expected output from the `iget` command is different in the python script, than if the command was executed just in the command line. This should hopefully less error prone and reproducible this way. 

The expected output is `CAT_INVALID_AUTHENTICATION`. but also this script is checking whether the irods module has been loaded.. if it hasn't echo message will prompt the user to do so.

finally to test this code yourself:
1. run `rm ~/.irods/.irodsA` to remove iRODS cache.
2. run `./solosis-cli irods iget-fastqs --samplefile PATH/TO/INPUT` (expected error message "[error] iRODS not loaded. please run `module load cellgen/irods` before re-running this solosis command.").
3. run `module load cellgen/irods` to load module.
4. run `./solosis-cli irods iget-fastqs --samplefile PATH/TO/INPUT` (expected error message "[error] run `iinit` before running this solosis command again.").
5. run `iinit` and then login in.
6. run  `./solosis-cli irods iget-fastqs --samplefile PATH/TO/INPUT` expected to error out due to "mv: cannot stat '/lustre/scratch126/cellgen/team298/data/samples/fastq/HCA_SkO14542035*". which can be resolved in a later issue.