### PR TITLE
Fixing Cellranger-count pytest to pass (issue #65)

### DIFF
--- a/sphinx/development.rst
+++ b/sphinx/development.rst
@@ -44,7 +44,7 @@ Set the :code:`PYTHONPATH` environment variable to the :code:`bin` directory whe
 
 ::
 
-    python -m pytest -q tests/test_class.py
+    python -m pytest -q tests/test_cli.py
 
 .. _pytest: https://docs.pytest.org/en/7.1.x/
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,8 +18,9 @@ def test_help():
     assert "Show this message and exit" in result.output
 
 
-def test_cellranger():
+def test_cellranger_count():
     runner = CliRunner()
-    result = runner.invoke(cli, ["cellranger", "--help"])
+    result = runner.invoke(cli, ["alignment", "cellranger-count", "--help"])
+    print(result.output)
     assert result.exit_code == 0
     assert "Show this message and exit" in result.output


### PR DESCRIPTION
# Pull Request Template

## Summary
**What does this pull request address? Provide a brief description.**
Fixed the pytest for cellranger count, so that it is now passing rather than failing.


## Changes Made
**List major changes or highlight key points:**
- Updated pytest for cellranger-count command, this is now passing 
- Updated sphinx docs to updated path for testing pytest locally (filename was outdated).


## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [x] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

