### PR TITLE
Feature/disk-usage command add irods archive/team298 information

### DIFF
--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -25,6 +25,9 @@ fi
 
 # Configure paths
 TEAM_DATA_DIR=/lustre/scratch126/cellgen/team298/data
+=$TEAM_DATA_DIR/reports/storage/
+# Create the output dir
+mkdir -p "$OUTPUT_DIR"
 
 # lustre
 #lfs quota -g team298 -h /lustre/scratch126
@@ -53,7 +56,7 @@ wh_percent=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $5}')
 #/archive/team298 irods 
 iquest --no-page -z archive "%s/%s,%s" "select COLL_NAME, DATA_NAME, DATA_SIZE where COLL_NAME like \
 '/archive/team298%'" | tail -n +2 | sort | uniq > $TEAM_DATA_DIR/reports/storage/team298.irods.csv
-archive_used=$(cut -f 2 -d , $TEAM_DATA_DIR/reports/storage/team298.irods.csv | paste -sd+ | bc | numfmt --to iec --format "%4.2f")
+archive_used=$(cut -f 2 -d , $OUTPUT_DIR/team298.irods.csv | paste -sd+ | bc | numfmt --to iec --format "%4.2f")
 archive_size="20T"
 #remove T's
 archive_used_num=$(echo "$archive_used" | sed 's/[A-Za-z]//g')

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -55,7 +55,7 @@ wh_avail=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $4}')
 wh_percent=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $5}')
 #/archive/team298 irods 
 iquest --no-page -z archive "%s/%s,%s" "select COLL_NAME, DATA_NAME, DATA_SIZE where COLL_NAME like \
-'/archive/team298%'" | tail -n +2 | sort | uniq > $TEAM_DATA_DIR/reports/storage/team298.irods.csv
+'/archive/team298%'" | tail -n +2 | sort | uniq > $OUTPUT_DIR/team298.irods.csv
 archive_used=$(cut -f 2 -d , $OUTPUT_DIR/team298.irods.csv | paste -sd+ | bc | numfmt --to iec --format "%4.2f")
 archive_size="20T"
 #remove T's

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -55,7 +55,7 @@ wh_avail=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $4}')
 wh_percent=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $5}')
 #/archive/team298 irods 
 iquest --no-page -z archive "%s/%s,%s" "select COLL_NAME, DATA_NAME, DATA_SIZE where COLL_NAME like \
-'/archive/team298%'" | tail -n +2 | sort | uniq > $OUTPUT_DIR/team298.irods.csv
+'/archive/team298%'" | tail -n +2 | sort | uniq > $TEAM_DATA_DIR/reports/storage/team298.irods.csv
 archive_used=$(cut -f 2 -d , $OUTPUT_DIR/team298.irods.csv | paste -sd+ | bc | numfmt --to iec --format "%4.2f")
 archive_size="20T"
 #remove T's

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -74,10 +74,10 @@ data=("Lustre $lustre_size $lustre_used $lustre_avail $lustre_percent"
         "/archive/team298 $archive_used $archive_size - $archive_percent")
 
 # Define headers
-printf "%-18s %-6s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"
-printf "%-18s %-6s %-8s %-6s %-6s\n" "-------------" "-----" "------" "-----" "-----"
+printf "%-18s %-8s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"
+printf "%-18s %-8s %-8s %-6s %-6s\n" "-------------" "------" "------" "-----" "-----"
 
 # Loop through data
 for row in "${data[@]}"; do
-    printf "%-18s %-6s %-8s %-6s %-6s\n" $row
+    printf "%-18s %-8s %-8s %-6s %-6s\n" $row
 done

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -74,10 +74,10 @@ data=("Lustre $lustre_size $lustre_used $lustre_avail $lustre_percent"
         "/archive/team298 $archive_used $archive_size - $archive_percent")
 
 # Define headers
-printf "%-16s %-6s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"
-printf "%-16s %-6s %-8s %-6s %-6s\n" "-------------" "-----" "------" "-----" "-----"
+printf "%-18s %-6s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"
+printf "%-18s %-6s %-8s %-6s %-6s\n" "-------------" "-----" "------" "-----" "-----"
 
 # Loop through data
 for row in "${data[@]}"; do
-    printf "%-16s %-6s %-8s %-6s %-6s\n" $row
+    printf "%-18s %-6s %-8s %-6s %-6s\n" $row
 done

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -25,7 +25,7 @@ fi
 
 # Configure paths
 TEAM_DATA_DIR=/lustre/scratch126/cellgen/team298/data
-=$TEAM_DATA_DIR/reports/storage/
+OUTPUT_DIR="$TEAM_DATA_DIR/reports/storage/"
 # Create the output dir
 mkdir -p "$OUTPUT_DIR"
 

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -71,13 +71,13 @@ archive_percent=$(echo $((archive_used_int*100/archive_size_int))'%')
 data=("Lustre $lustre_size $lustre_used $lustre_avail $lustre_percent"
         "nfs $nfs_size $nfs_used $nfs_avail $nfs_percent"
         "warehouse $wh_size $wh_used $wh_avail $wh_percent"
-        "/archive/team298 $archive_used $archive_size $archive_percent")
+        "/archive/team298 $archive_used $archive_size - $archive_percent")
 
 # Define headers
-printf "%-12s %-6s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"
-printf "%-12s %-6s %-8s %-6s %-6s\n" "---------" "-----" "------" "-----" "-----"
+printf "%-16s %-6s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"
+printf "%-16s %-6s %-8s %-6s %-6s\n" "-------------" "-----" "------" "-----" "-----"
 
 # Loop through data
 for row in "${data[@]}"; do
-    printf "%-12s %-6s %-8s %-6s %-6s\n" $row
+    printf "%-16s %-6s %-8s %-6s %-6s\n" $row
 done

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -10,13 +10,6 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-#removing for now.. chatGPT has a decent response to this though
-# Ensure at least one argument is provided
-#if [ "$#" -lt 1 ]; then
-#  echo "Usage: $0" >&2
-#  exit 1
-#fi
-
 # Load irods module
 if ! module load cellgen/irods; then
   echo "Error: Failed to load irods module" >&2
@@ -55,10 +48,10 @@ wh_avail=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $4}')
 wh_percent=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $5}')
 #/archive/team298 irods 
 iquest --no-page -z archive "%s/%s,%s" "select COLL_NAME, DATA_NAME, DATA_SIZE where COLL_NAME like \
-'/archive/team298%'" | tail -n +2 | sort | uniq > $TEAM_DATA_DIR/reports/storage/team298.irods.csv
+'/archive/team298%'" | tail -n +2 | sort | uniq > $OUTPUT_DIR/team298.irods.csv
 archive_used=$(cut -f 2 -d , $OUTPUT_DIR/team298.irods.csv | paste -sd+ | bc | numfmt --to iec --format "%4.2f")
 archive_size="20T"
-#remove T's
+#archive- remove T's
 archive_used_num=$(echo "$archive_used" | sed 's/[A-Za-z]//g')
 archive_size_num=$(echo "$archive_size" | sed 's/[A-Za-z]//g')
 #turn archive numbers into integers

--- a/bin/filesystem/disk-usage/submit.sh
+++ b/bin/filesystem/disk-usage/submit.sh
@@ -17,6 +17,15 @@ set -e
 #  exit 1
 #fi
 
+# Load irods module
+if ! module load cellgen/irods; then
+  echo "Error: Failed to load irods module" >&2
+  exit 1
+fi
+
+# Configure paths
+TEAM_DATA_DIR=/lustre/scratch126/cellgen/team298/data
+
 # lustre
 #lfs quota -g team298 -h /lustre/scratch126
 lustre_size=$(lfs quota -g team298 -h /lustre/scratch126 | awk '/\/lustre\/scratch126/ {print $4}')
@@ -41,11 +50,25 @@ wh_size=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $2}')
 wh_used=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $3}')
 wh_avail=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $4}')
 wh_percent=$(df -h /warehouse/team298_wh01 | sed -n '2p' | awk '{print $5}')
+#/archive/team298 irods 
+iquest --no-page -z archive "%s/%s,%s" "select COLL_NAME, DATA_NAME, DATA_SIZE where COLL_NAME like \
+'/archive/team298%'" | tail -n +2 | sort | uniq > $TEAM_DATA_DIR/reports/storage/team298.irods.csv
+archive_used=$(cut -f 2 -d , $TEAM_DATA_DIR/reports/storage/team298.irods.csv | paste -sd+ | bc | numfmt --to iec --format "%4.2f")
+archive_size="20T"
+#remove T's
+archive_used_num=$(echo "$archive_used" | sed 's/[A-Za-z]//g')
+archive_size_num=$(echo "$archive_size" | sed 's/[A-Za-z]//g')
+#turn archive numbers into integers
+archive_used_int=${archive_used_num%.*}
+archive_size_int=${archive_size_num%.*}
+#archive usage percentage 
+archive_percent=$(echo $((archive_used_int*100/archive_size_int))'%')
 
 # Array of data
 data=("Lustre $lustre_size $lustre_used $lustre_avail $lustre_percent"
         "nfs $nfs_size $nfs_used $nfs_avail $nfs_percent"
-        "warehouse $wh_size $wh_used $wh_avail $wh_percent")
+        "warehouse $wh_size $wh_used $wh_avail $wh_percent"
+        "/archive/team298 $archive_used $archive_size $archive_percent")
 
 # Define headers
 printf "%-12s %-6s %-8s %-6s %-6s\n" "workspace" "size" "used" "avail" "use%"

--- a/solosis/commands/filesystem/disk_usage.py
+++ b/solosis/commands/filesystem/disk_usage.py
@@ -13,7 +13,7 @@ def cmd():
     Check disk usage for Team298 workspaces.
 
     This command retrieves the disk usage for Team298 workspaces
-    including NFS, Lustre, or warehouse storage systems.
+    including NFS, Lustre, Warehouse & /archive/team298 irods storage systems.
     """
     ctx = click.get_current_context()
     echo_message(

--- a/solosis/commands/filesystem/disk_usage.py
+++ b/solosis/commands/filesystem/disk_usage.py
@@ -13,7 +13,7 @@ def cmd():
     Check disk usage for Team298 workspaces.
 
     This command retrieves the disk usage for Team298 workspaces
-    including NFS, Lustre, Warehouse & /archive/team298 irods storage systems.
+    including NFS, Lustre, Warehouse & `/archive/team298` irods storage systems.
     """
     ctx = click.get_current_context()
     echo_message(


### PR DESCRIPTION
# Pull Request Template

## Summary
add irods `archive/team298` capacity information to `disk-usage` command 


## Changes Made
**List major changes or highlight key points:**
- Added `archive/team298` storage capacity information (amount used, percentage used & total storage)
- Updated disk_usage.py click command message to include changes made- this also updates the sphinx docs


## Checklist
- [x] The code adheres to the project's style guidelines
- [x] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
To run:
`./solosis-cli filesystem disk-usage`
Expected output:
```
  SOLOSIS    ~  version 0.3.0
[info] Starting Process: disk-usage
[progress] Calculating disk usage for team298 ...
[progress] 
workspace          size     used     avail  use%  
-------------      ------   ------   -----  ----- 
Lustre             45T      40.48T   5T     88%   
nfs                60T      52T      9.0T   86%   
warehouse          1.0T     769G     256G   76%   
/archive/team298   18.11T   20T      -      90%
```

