### PR TITLE
correct path to ref in .sh script #110

### DIFF
--- a/bin/cellranger/cellranger_arc_count.sh
+++ b/bin/cellranger/cellranger_arc_count.sh
@@ -29,7 +29,7 @@ VERSION="$4"
 CPU="$5"
 MEM="$6"
 BAM_FLAG=""  # Default to generating BAM files
-REF="/software/cellgen/cellgeni/refdata-cellranger-arc-GRCh38-2020-A-2.0.0"  # Reference genome
+REF="/software/cellgen/cellgeni/refdata_10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0"  # Reference genome
 
 # Handle optional --no-bam flag (disables BAM file generation)
 if [ "$7" == "--no-bam" ]; then


### PR DESCRIPTION
# Pull Request Template

## Summary
when running cellranger arc count the job failed due to incorrect path to ref genome. here is the error message: 
`error: Invalid value for '--reference <PATH>': No such file or directory: '/software/cellgen/cellgeni/refdata-cellranger-arc-GRCh38-2020-A-2.0.0'`
I've ensured the correct path and added this in the cellranger-arc-count.sh 

correct path: `/software/cellgen/cellgeni/refdata_10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0`

## Changes Made
**List major changes or highlight key points:**
- corrected path to ref genome in cellranger-arc-count.sh 
- Change 2
- Change 3


## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

