### PR TITLE
Validate nf-irods-to-fastq metadata

### DIFF
--- a/bin/irods/nf-irods-to-fastq-metadata.sh
+++ b/bin/irods/nf-irods-to-fastq-metadata.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# submit.sh - Environment setup for pull-fastq processing using Nextflow
+
+# Usage:
+#   ./submit.sh <sample_file> <random_id>
+#
+# Parameters:
+#   <sample_file> - Path to a file containing sample IDs, one per line.
+#   <random_id> - A unique 8-character identifier for this run.
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Ensure exactly two arguments are provided
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <sample_file> <random_id>" >&2
+  exit 1
+fi
+
+# Assign command-line arguments to variables
+SAMPLE_FILE="$1"
+RANDOM_ID="$2"
+
+# Verify that the sample file exists and is not empty
+if [ ! -f "$SAMPLE_FILE" ] || [ ! -s "$SAMPLE_FILE" ]; then
+  echo "Error: Sample file '$SAMPLE_FILE' does not exist or is empty." >&2
+  exit 1
+fi
+
+# Load necessary modules
+MODULES=("irods" "conda" "nextflow" "singularity")
+for MODULE in "${MODULES[@]}"; do
+  if ! module load cellgen/"$MODULE"; then
+    echo "Error: Failed to load $MODULE module" >&2
+    exit 1
+  fi
+done
+
+# Setup Nextflow work directory
+mkdir -p "$TEAM_TMP_DIR/nxf"
+chmod -R g+w "$TEAM_TMP_DIR/nxf" >/dev/null 2>&1 || true
+export NXF_WORK="$TEAM_TMP_DIR/nxf"
+
+# Setup output directory with timestamp and random ID
+OUTPUT_DIR="$TEAM_TMP_DIR/${RANDOM_ID}"
+mkdir -p "$OUTPUT_DIR"
+chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
+cd "$OUTPUT_DIR"
+
+# Run Nextflow process with the sample file
+echo "Running Nextflow process for samples listed in: $SAMPLE_FILE"
+nextflow run cellgeni/nf-irods-to-fastq -r main main.nf \
+  --findmeta "$SAMPLE_FILE" \
+  --publish_dir "$OUTPUT_DIR"
+
+chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true

--- a/bin/irods/nf-irods-to-fastq-metadata.sh
+++ b/bin/irods/nf-irods-to-fastq-metadata.sh
@@ -48,7 +48,7 @@ chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
 cd "$OUTPUT_DIR"
 
 # Run Nextflow process with the sample file
-echo "Running Nextflow process for samples listed in: $SAMPLE_FILE"
+echo "Checking metadata for samples listed in: $SAMPLE_FILE"
 nextflow run cellgeni/nf-irods-to-fastq -r main main.nf \
   --findmeta "$SAMPLE_FILE" \
   --publish_dir "$OUTPUT_DIR"

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -57,6 +57,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                 )
             )
             popen([imeta_report_script, sample, report_path])
+
             if os.path.exists(report_path):
                 df = pd.read_csv(
                     report_path, header=None, names=["collection_type", "path"]
@@ -81,12 +82,8 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                                 f"Skipping {collection_name}, already exists in {cellranger_dir}"
                             )
                             continue
-
-                        command = f"iget -r {path} {cellranger_dir}"
+                        command = f"iget -r {path} {cellranger_dir} && chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true"
                         tmpfile.write(command + "\n")
-            tmpfile.write(
-                f"chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true" + "\n"
-            )
 
     submit_lsf_job_array(
         command_file=tmpfile.name,

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -77,8 +77,10 @@ def cmd(sample, samplefile, debug):
 
     # Check if metadata TSV file exists
     if not os.path.exists(metadata_tsv_path):
-        logger.error(f"Metadata TSV file '{metadata_tsv_path}' not found.")
+        logger.error(f"Metadata TSV file {metadata_tsv_path} not found.")
         raise click.Abort()
+    else:
+        logger.error(f"Metadata TSV file saved: {metadata_tsv_path}")
 
     # Read and validate TSV file
     validate_library_type(metadata_tsv_path)

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -81,11 +81,7 @@ def cmd(sample, samplefile, debug):
         raise click.Abort()
 
     # Read and validate TSV file
-    try:
-        validate_library_type(metadata_tsv_path)
-    except Exception as e:
-        logger.error(f"Error reading metadata TSV file: {e}")
-        raise click.Abort()
+    validate_library_type(metadata_tsv_path)
 
     irods_to_fastq_script = os.path.abspath(
         os.path.join(

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import secrets
 import tempfile
 
 import click
@@ -48,7 +49,7 @@ def cmd(sample, samplefile, debug):
             samples_to_download.append(sample)
 
     if not samples_to_download:
-        logger.warning(f"All samples already proccessed.")
+        logger.warning("All samples already processed.")
         raise click.Abort()
 
     with tempfile.NamedTemporaryFile(
@@ -59,13 +60,66 @@ def cmd(sample, samplefile, debug):
         for sample in samples_to_download:
             tmpfile.write(sample + "\n")
 
-    irods_to_fastq_script = os.path.abspath(
+    # Run the metadata script first
+    random_id = secrets.token_hex(4)
+    metadata_script = os.path.abspath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../../../bin/irods/nf-irods-to-fastq-metadata.sh",
+        )
+    )
+    popen([metadata_script, tmpfile.name, random_id])
+
+    # Define expected TSV file path
+    metadata_tsv_path = os.path.join(
+        os.getenv("TEAM_TMP_DIR"), random_id, "metadata", "metadata.tsv"
+    )
+
+    logger.error(metadata_tsv_path)
+    click.Abort()
+
+    # Check if metadata TSV file exists
+    if not os.path.exists(metadata_tsv_path):
+        logger.error(f"Metadata TSV file '{metadata_tsv_path}' not found.")
+        raise click.Abort()
+
+    # Read and validate TSV file
+    valid_samples = []
+    try:
+        with open(metadata_tsv_path, "r") as tsv_file:
+            for line in tsv_file:
+                columns = line.strip().split("\t")
+                if len(columns) < 2:
+                    logger.warning(f"Skipping malformed line: {line.strip()}")
+                    continue
+
+                sample_id, status = columns[0], columns[1]
+                if status.lower() == "valid":
+                    valid_samples.append(sample_id)
+                else:
+                    logger.warning(
+                        f"Skipping sample '{sample_id}' due to invalid status."
+                    )
+
+    except Exception as e:
+        logger.error(f"Error reading metadata TSV file: {e}")
+        raise click.Abort()
+
+    # Filter only valid samples for download
+    samples_to_download = [s for s in samples_to_download if s in valid_samples]
+
+    if not samples_to_download:
+        logger.warning("No valid samples available for download.")
+        raise click.Abort()
+
+    # Run the actual fastq download script
+    fastq_script = os.path.abspath(
         os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             "../../../bin/irods/nf-irods-to-fastq.sh",
         )
     )
-    popen([irods_to_fastq_script, tmpfile.name])
+    popen([fastq_script, tmpfile.name])
 
 
 if __name__ == "__main__":

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -80,7 +80,7 @@ def cmd(sample, samplefile, debug):
         logger.error(f"Metadata TSV file {metadata_tsv_path} not found.")
         raise click.Abort()
     else:
-        logger.error(f"Metadata TSV file saved: {metadata_tsv_path}")
+        logger.info(f"Metadata TSV file saved: {metadata_tsv_path}")
 
     # Read and validate TSV file
     validate_library_type(metadata_tsv_path)

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -1,5 +1,6 @@
 import click
 import pandas as pd
+from tabulate import tabulate
 
 from solosis.utils.state import logger
 
@@ -106,7 +107,11 @@ def validate_library_type(tsv_file):
     invalid_samples = invalid_samples[invalid_samples > 1]
 
     if not invalid_samples.empty:
-        logger.error("The following sample IDs have multiple library types:")
-        print(invalid_samples.to_string())
-        logger.error("This command will now be terminated with no further action")
+        logger.error(
+            "The following sample IDs have multiple library types, and will now terminate:"
+        )
+        table = tabulate(
+            invalid_samples, tablefmt="pretty", numalign="left", stralign="left"
+        )
+        logger.info(f"Problematic samples... \n{table}")
         raise click.Abort()

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -118,6 +118,7 @@ def validate_library_type(tsv_file):
             tablefmt="pretty",
             numalign="left",
             stralign="left",
+            showindex=False,
         )
         logger.info(f"Problematic samples... \n{table}")
         raise click.Abort()

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -108,4 +108,5 @@ def validate_library_type(tsv_file):
     if not invalid_samples.empty:
         logger.error("The following sample IDs have multiple library types:")
         print(invalid_samples.to_string())
+        logger.error("This command will now be terminated with no further action")
         raise click.Abort()

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -107,11 +107,17 @@ def validate_library_type(tsv_file):
     invalid_samples = invalid_samples[invalid_samples > 1]
 
     if not invalid_samples.empty:
+        invalid_samples_df = invalid_samples.reset_index()
+        invalid_samples_df.columns = ["Sample ID", "Library Type Count"]
         logger.error(
             "The following sample IDs have multiple library types, and will now terminate:"
         )
         table = tabulate(
-            invalid_samples, tablefmt="pretty", numalign="left", stralign="left"
+            invalid_samples_df,
+            headers="keys",
+            tablefmt="pretty",
+            numalign="left",
+            stralign="left",
         )
         logger.info(f"Problematic samples... \n{table}")
         raise click.Abort()

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -120,5 +120,5 @@ def validate_library_type(tsv_file):
             stralign="left",
             showindex=False,
         )
-        logger.info(f"Problematic samples... \n{table}")
+        logger.error(f"Problematic samples... \n{table}")
         raise click.Abort()

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -107,5 +107,5 @@ def validate_library_type(tsv_file):
 
     if not invalid_samples.empty:
         logger.error("The following sample IDs have multiple library types:")
-        logger.error(invalid_samples.to_string())
+        print(invalid_samples.to_string())
         raise click.Abort()

--- a/solosis/utils/input_utils.py
+++ b/solosis/utils/input_utils.py
@@ -90,3 +90,22 @@ def process_metadata_file(metadata):
         raise click.Abort()
 
     return samples
+
+
+def validate_library_type(tsv_file):
+    """
+    Validates that each sample ID in the TSV file has only one unique library_type.
+    If multiple library_type values are found for a sample ID, the process is aborted.
+
+    :param tsv_file: Path to the TSV file
+    """
+    df = pd.read_csv(tsv_file, sep="\t", dtype=str)
+
+    # Count unique library_type values for each sample
+    invalid_samples = df.groupby("sample")["library_type"].nunique()
+    invalid_samples = invalid_samples[invalid_samples > 1]
+
+    if not invalid_samples.empty:
+        logger.error("The following sample IDs have multiple library types:")
+        logger.error(invalid_samples.to_string())
+        raise click.Abort()

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -22,6 +22,10 @@ def popen(
         # Create a deque to hold the last 5 lines of output
         recent_lines = deque(maxlen=5)
 
+        # Print 5 empty lines to start
+        for _ in range(5):
+            print()
+
         # Process stdout in real-time
         for line in process.stdout:
             timestamp = datetime.now().strftime("%H:%M:%S")
@@ -29,8 +33,8 @@ def popen(
                 f"[{timestamp}] {line.strip()}"
             )  # Add the new line with timestamp
 
-            # Move the cursor up by the number of lines currently in recent_lines
-            sys.stdout.write("\033[F" * len(recent_lines))  # Move the cursor up
+            # Move the cursor up by 5 lines
+            sys.stdout.write("\033[F" * 5)
 
             # Print the last 5 lines (or fewer, depending on the deque's size)
             for recent_line in recent_lines:

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from datetime import datetime
 
 from solosis.utils.state import logger
@@ -14,12 +15,16 @@ def popen(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            bufsize=1,  # Line buffering
         )
 
         # Process stdout in real-time
         for line in process.stdout:
             timestamp = datetime.now().strftime("%H:%M:%S")
-            print(f"[{timestamp}] {line.strip()}", "progress")
+            sys.stdout.write(
+                f"\r[{timestamp}] {line.strip()}"
+            )  # Use \r to overwrite the line
+            sys.stdout.flush()
 
         for line in process.stderr:
             logger.error(f"{line.strip()}")

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -18,13 +18,26 @@ def popen(
             bufsize=1,  # Line buffering
         )
 
+        # Dictionary to store each process line and its current status
+        lines = {}
+
         # Process stdout in real-time
         for line in process.stdout:
             timestamp = datetime.now().strftime("%H:%M:%S")
-            sys.stdout.write(
-                f"\r[{timestamp}] {line.strip()}"
-            )  # Use \r to overwrite the line
-            sys.stdout.flush()
+            line = line.strip()
+
+            # Check if this line is being updated (e.g., by checking if it was previously printed)
+            if line not in lines:
+                lines[line] = False  # Mark it as a new line to be printed
+
+            # If a line is marked as updated, overwrite it
+            if lines[line]:
+                sys.stdout.write(f"\r[{timestamp}] {line}")
+                sys.stdout.flush()
+            else:
+                sys.stdout.write(f"[{timestamp}] {line}\n")
+                sys.stdout.flush()
+                lines[line]
 
         for line in process.stderr:
             logger.error(f"{line.strip()}")

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -19,8 +19,8 @@ def popen(
             bufsize=1,  # Line buffering
         )
 
-        # Create a deque to hold the last 5 lines of output
-        recent_lines = deque(maxlen=5)
+        # Create a deque to hold the last 5 lines of output with an initial minimum length of 5 (empty lines)
+        recent_lines = deque([""] * 5, maxlen=5)
 
         # Print 5 empty lines to start
         for _ in range(5):

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -15,31 +15,16 @@ def popen(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            bufsize=5,  # Line buffering
         )
 
-        # Create a deque with a max length of 4 to keep the most recent 4 lines
-        recent_lines = deque(maxlen=4)
-
-        # Print initial message indicating the process is running
-        sys.stdout.write("Process started...\n")
-        sys.stdout.flush()
-
+        # Process stdout in real-time
         for line in process.stdout:
-            # Add the new line to the deque (it will automatically discard the oldest one if > 4 lines)
-            recent_lines.append(line.strip())
-
-            # Clear only the lines printed by this block (move cursor up by the number of lines in recent_lines)
+            timestamp = datetime.now().strftime("%H:%M:%S")
             sys.stdout.write(
-                "\033[F" * len(recent_lines)
-            )  # Move cursor up by the number of lines
-
-            # Print all the recent lines in the deque
-            for recent_line in recent_lines:
-                print(recent_line)
-
-            sys.stdout.flush()
-
-        print()  # Final print after all lines are done printing
+                f"\r[{timestamp}] {line.strip()}"
+            )  # Use \r to overwrite the line
+            sys.stdout.flush()  # Ensure immediate update
 
         for line in process.stderr:
             logger.error(f"{line.strip()}")

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -16,9 +16,24 @@ def popen(
             text=True,
         )
 
+        output_lines = []  # Store output lines for tracking
+
         for line in process.stdout:
-            sys.stdout.write(f"\r{line.strip()}")
-            sys.stdout.flush()
+            output_lines.append(line.strip())
+
+            # Move the cursor up for each previous line
+            for _ in range(len(output_lines)):
+                sys.stdout.write("\033[F")  # Move cursor up
+
+            # Clear the lines
+            sys.stdout.write("\033[J")  # Clear from cursor to end of screen
+
+            # Reprint the updated output
+            for out_line in output_lines:
+                print(out_line)
+
+            sys.stdout.flush()  # Ensure immediate update
+
         print()
 
         for line in process.stderr:

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from solosis.utils.state import logger
 
@@ -16,7 +17,9 @@ def popen(
         )
 
         for line in process.stdout:
-            logger.info(f"{line.strip()}")
+            sys.stdout.write(f"\r{line.strip()}")
+            sys.stdout.flush()
+        print()
 
         for line in process.stderr:
             logger.error(f"{line.strip()}")

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -20,16 +20,20 @@ def popen(
         # Create a deque with a max length of 4 to keep the most recent 4 lines
         recent_lines = deque(maxlen=4)
 
+        # Print initial message indicating the process is running
+        sys.stdout.write("Process started...\n")
+        sys.stdout.flush()
+
         for line in process.stdout:
             # Add the new line to the deque (it will automatically discard the oldest one if > 4 lines)
             recent_lines.append(line.strip())
 
-            # Clear the screen (this simulates overwriting the output)
+            # Clear only the lines printed by this block (move cursor up by the number of lines in recent_lines)
             sys.stdout.write(
                 "\033[F" * len(recent_lines)
             )  # Move cursor up by the number of lines
 
-            # Print all the recent lines
+            # Print all the recent lines in the deque
             for recent_line in recent_lines:
                 print(recent_line)
 

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -16,31 +16,19 @@ def popen(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            bufsize=1,  # Line buffering
+            bufsize=1,
         )
 
-        # Create a deque to hold the last 5 lines of output with an initial minimum length of 5 (empty lines)
-        recent_lines = deque([""] * 5, maxlen=5)
-
-        # Print 5 empty lines to start
-        for _ in range(5):
-            print()
-
         # Process stdout in real-time
+        lines = 7
+        recent_lines = deque([""] * lines, maxlen=lines)
         for line in process.stdout:
             timestamp = datetime.now().strftime("%H:%M:%S")
-            recent_lines.append(
-                f"[{timestamp}] {line.strip()}"
-            )  # Add the new line with timestamp
-
-            # Move the cursor up by 5 lines
-            sys.stdout.write("\033[F" * 5)
-
-            # Print the last 5 lines (or fewer, depending on the deque's size)
+            recent_lines.append(f"[{timestamp}] {line.strip()}")
+            sys.stdout.write("\033[F" * lines)
             for recent_line in recent_lines:
                 print(recent_line)
-
-            sys.stdout.flush()  # Ensure immediate update
+            sys.stdout.flush()
 
         for line in process.stderr:
             logger.error(f"{line.strip()}")

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -1,6 +1,6 @@
 import subprocess
 import sys
-from collections import deque
+from datetime import datetime
 
 from solosis.utils.state import logger
 

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -22,6 +22,8 @@ def popen(
         # Process stdout in real-time
         lines = 7
         recent_lines = deque([""] * lines, maxlen=lines)
+        for _ in range(lines):
+            print()
         for line in process.stdout:
             timestamp = datetime.now().strftime("%H:%M:%S")
             recent_lines.append(f"[{timestamp}] {line.strip()}")

--- a/solosis/utils/subprocess_utils.py
+++ b/solosis/utils/subprocess_utils.py
@@ -1,5 +1,5 @@
 import subprocess
-import sys
+from datetime import datetime
 
 from solosis.utils.state import logger
 
@@ -16,25 +16,10 @@ def popen(
             text=True,
         )
 
-        output_lines = []  # Store output lines for tracking
-
+        # Process stdout in real-time
         for line in process.stdout:
-            output_lines.append(line.strip())
-
-            # Move the cursor up for each previous line
-            for _ in range(len(output_lines)):
-                sys.stdout.write("\033[F")  # Move cursor up
-
-            # Clear the lines
-            sys.stdout.write("\033[J")  # Clear from cursor to end of screen
-
-            # Reprint the updated output
-            for out_line in output_lines:
-                print(out_line)
-
-            sys.stdout.flush()  # Ensure immediate update
-
-        print()
+            timestamp = datetime.now().strftime("%H:%M:%S")
+            print(f"[{timestamp}] {line.strip()}", "progress")
 
         for line in process.stderr:
             logger.error(f"{line.strip()}")


### PR DESCRIPTION
## Summary
This PR splits the nf-irods-to-fastq pipeline into a two step process, and validates the `metadata.tsv` to check unique `library_type` values for each ID. Currently it will abort when multiple libraries for each sample ID are found. This prevents the core problem of incorrect FASTQs being generated. 

Fixes #82 

This PR also tweaks the way `stdout` is handled to better readability. 

## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


