### PR TITLE
create iget-cellranger logfile including potential path to outputs 

### DIFF
--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -88,7 +88,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                         command = f"iget -r {path} {cellranger_dir} ; chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true"
                         tmpfile.write(command + "\n")
                         logger.info(
-                            f"Collection ({collection_name}) for sample {sample} will be downloaded to {output_dir}"
+                            f'Collection "{collection_name}" for sample "{sample}" will be downloaded to: {output_dir}'
                         )
 
     submit_lsf_job_array(

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -96,6 +96,14 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
         queue=queue,
     )
 
+    if downloaded_samples:
+        log_file = os.path.join(os.getcwd(), "iget-cellranger.log")
+        df = pd.DataFrame(downloaded_samples, columns=["sample", "cellranger_dir"])
+        df.to_csv(log_file, index=False)
+        logger.info(f"Log file of output paths: {log_file}")
+    else:
+        logger.info("No downloads were logged, no log file generated.")
+
 
 if __name__ == "__main__":
     cmd()

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -88,7 +88,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                         command = f"iget -r {path} {cellranger_dir} ; chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true"
                         tmpfile.write(command + "\n")
                         logger.info(
-                            f"Collection {collection_name} for {sample} will be downloaded to {cellranger_dir}"
+                            f"Collection ({collection_name}) for sample {sample} will be downloaded to {output_dir}"
                         )
 
     submit_lsf_job_array(

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -86,7 +86,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
 
                         command = f"iget -r {path} {cellranger_dir}"
                         tmpfile.write(command + "\n")
-                        samples_to_download.append((sample, path))
+                        samples_to_download.append((sample, cellranger_dir))
             tmpfile.write(
                 f"chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true" + "\n"
             )

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -86,7 +86,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
 
                         command = f"iget -r {path} {cellranger_dir}"
                         tmpfile.write(command + "\n")
-                        samples_to_download.append((sample, cellranger_dir))
+                        samples_to_download.append((sample, output_dir))
             tmpfile.write(
                 f"chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true" + "\n"
             )


### PR DESCRIPTION
# Pull Request Template

## Summary
creates a logfile of samples that will be downloaded by iget-cellranger (the samples have gone through all available logic to be valid samples). this log file can be used to quickly find outputs but also can has plans to be input file for cellbender see issue #115 


## Changes Made
**List major changes or highlight key points:**
- created logfile to be made in the execution directory of sample id and 
to test: 
`$ ./solosis-cli irods iget-cellranger --sample HCA_SkO14542035 --mem 1200 --cpu 1 --queue small `

the log file (`iget-cellranger.log`)
```
sample,cellranger_dir
HCA_SkO14542035,/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542035/cellranger/cellranger700_count_48214_HCA_SkO14542035_GRCh38-2020-A
HCA_SkO14542035,/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542035/cellranger/cellranger700_count_48282_HCA_SkO14542035_GRCh38-2020-A
```

example with `--samplefile`:
`./solosis-cli irods iget-cellranger --samplefile ../../sol-input.csv --mem 1200 --cpu 1 --queue small`
the log file:
```
sample,cellranger_dir
HCA_SkO14542035,/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542035/cellranger/cellranger700_count_48214_HCA_SkO14542035_GRCh38-2020-A
HCA_SkO14542035,/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542035/cellranger/cellranger700_count_48282_HCA_SkO14542035_GRCh38-2020-A
HCA_SkO14542036,/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542036/cellranger/cellranger700_count_48214_HCA_SkO14542036_GRCh38-2020-A
HCA_SkO14542036,/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542036/cellranger/cellranger700_count_48282_HCA_SkO14542036_GRCh38-2020-A
```



## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

