### PR TITLE
Appended timestamp to cellbender output as identifier

### DIFF
--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -83,8 +83,8 @@ echo "Expected cells: ${EXPECTED_CELLS_FLAG:-Auto-detected}"
 
 # Construct command
 CELLBENDER_CMD=("cellbender remove-background"
-  "--input \"$CELLRANGER_DIR/raw_feature_bc_matrix.h5\""
-  "--output \"$OUTPUT_DIR/${USER}_$(date +%Y%m%d).h5\""
+  "--input=$CELLRANGER_DIR/raw_feature_bc_matrix.h5"
+  "--output=$OUTPUT_DIR/${SAMPLE_ID}_${USER}_$(date +%Y%m%d).h5"
 )
 [ -n "$GPU_FLAG" ] && CELLBENDER_CMD+=("$GPU_FLAG")
 [ -n "$TOTAL_DROPLETS_FLAG" ] && CELLBENDER_CMD+=("$TOTAL_DROPLETS_FLAG")
@@ -93,7 +93,8 @@ CELLBENDER_CMD=("cellbender remove-background"
 # Print the command before execution
 echo "Executing: ${CELLBENDER_CMD[*]}"
 
-eval "${CELLBENDER_CMD[*]}"
+# Execute
+"${CELLBENDER_CMD[@]}"
 
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
 echo "Cellbender completed for sample: $SAMPLE_ID"

--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -64,7 +64,7 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # Load Cellbender module
-if ! module load cellgen/cellbender/; then
+if ! module load cellgen/cellbender/0.3.0; then
   echo "Error: Failed to load Cellbender module" >&2
   exit 1
 fi

--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -90,7 +90,7 @@ fi
 cellbender remove-background \
   "$GPU_FLAG" \
   --input "$CELLRANGER_DIR/raw_feature_bc_matrix.h5" \
-  --output "$OUTPUT_DIR/$SAMPLE_ID_CB_$(date +%Y%m%d).h5" \
+  --output "$OUTPUT_DIR/$SAMPLE_ID_$(date +%Y%m%d)_CB.h5" \
   "$TOTAL_DROPLETS_FLAG" \
   "$EXPECTED_CELLS_FLAG"
 # Q="gpu-normal"

--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -90,7 +90,7 @@ fi
 cellbender remove-background \
   "$GPU_FLAG" \
   --input "$CELLRANGER_DIR/raw_feature_bc_matrix.h5" \
-  --output "$OUTPUT_DIR/$SAMPLE_ID_$(date +%Y%m%d).h5" \
+  --output "$OUTPUT_DIR/$SAMPLE_ID_CB_$(date +%Y%m%d).h5" \
   "$TOTAL_DROPLETS_FLAG" \
   "$EXPECTED_CELLS_FLAG"
 # Q="gpu-normal"

--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -90,7 +90,7 @@ fi
 cellbender remove-background \
   "$GPU_FLAG" \
   --input "$CELLRANGER_DIR/raw_feature_bc_matrix.h5" \
-  --output "$OUTPUT_DIR/$SAMPLE_ID_$(date +%Y%m%d)_cb.h5" \
+  --output "$OUTPUT_DIR/$SAMPLE_ID_$(date +%Y%m%d).h5" \
   "$TOTAL_DROPLETS_FLAG" \
   "$EXPECTED_CELLS_FLAG"
 # Q="gpu-normal"

--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -90,7 +90,7 @@ fi
 cellbender remove-background \
   "$GPU_FLAG" \
   --input "$CELLRANGER_DIR/raw_feature_bc_matrix.h5" \
-  --output "$OUTPUT_DIR/$SAMPLE_ID-cb.h5" \
+  --output "$OUTPUT_DIR/$SAMPLE_ID_$(date +%Y%m%d)_cb.h5" \
   "$TOTAL_DROPLETS_FLAG" \
   "$EXPECTED_CELLS_FLAG"
 # Q="gpu-normal"

--- a/solosis/commands/history/uid.py
+++ b/solosis/commands/history/uid.py
@@ -49,7 +49,7 @@ def cmd(uid, debug):
     logger.info(f"{click.style('Timestamp', bold=True)}: {timestamp}")
     logger.info(f"{click.style('User', bold=True)}: {user}")
     logger.info(f"{click.style('Command', bold=True)}: {command}")
-    logger.info(f"{click.style('Logs', bold=True)}: {log_dir}")
+    logger.info(f"{click.style('Logs', bold=True)}")
     if log_dir.exists():
         for item in log_dir.iterdir():
             logger.info(f"├── {item}")

--- a/solosis/utils/lsf_utils.py
+++ b/solosis/utils/lsf_utils.py
@@ -108,7 +108,7 @@ def submit_lsf_job_array(
         num_commands = sum(1 for _ in f)
 
     if not execution_uid:
-        raise ValueError("execution_uid is empty or None. It must be a valid UUID.")
+        raise ValueError("The execution_uid is empty or None. It must be a valid UUID.")
 
     log_dir = Path(os.getenv("SOLOSIS_LOG_DIR")) / execution_uid
     os.makedirs(log_dir, exist_ok=True)
@@ -131,7 +131,7 @@ def submit_lsf_job_array(
 #BSUB -M {mem}
 #BSUB -R "span[hosts=1] select[mem>{mem}] rusage[mem={mem}]"
 #BSUB -G "{group}"
-#BSUB -q {queue}
+#BSUB -q "{queue}"
 """
     # Validate and add GPU options if specified
     if gpu:


### PR DESCRIPTION
# Pull Request Template

## Summary
vm11 stated that sometimes multiple users might want to run the same tool (in this case Cellbender) but currently the output files generated would either be overwritten or (mostly) the user would have to remove current outputs in order to generate their own. So a suggestion of an identifier was raised. I decided to at a timestamp as an identifier but this could be something more useful like `@USER`?   


## Changes Made
**List major changes or highlight key points:**
- Added timestamp to cellbender output 
Example of cellbender output file:
`HCA_SkO14189565_20250319_cb.h5`


## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

