### PR TITLE
fixing build-docs deploy-docs PR checks

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -22,6 +22,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
           pip install -r ./envs/doc-requirements.txt
+          pip install -r ./envs/dev-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
+          pip install -r ./envs/doc-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r ./envs/dev/requirements.txt
+          pip install -r ./envs/requirements.txt
+          pip install -r ./envs/doc-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
-          pip install -r ./envs/doc-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
-          pip install -r ./envs/doc-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
+          pip install -r ./envs/doc-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
-          pip install -r ./envs/dev-requirements.txt
+          pip install -r ./envs/doc-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -27,6 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
           pip install -r ./envs/doc-requirements.txt
+          pip install -r ./envs/dev-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r ./envs/dev/requirements.txt
+          pip install -r ./envs/requirements.txt
+          pip install -r ./envs/dev-requirements.txt
           pip install -e .
       - name: Sphinx Build
         working-directory: ./sphinx

--- a/.github/workflows/tests-python.yml
+++ b/.github/workflows/tests-python.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests-python.yml
+++ b/.github/workflows/tests-python.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./envs/requirements.txt
+          pip install -r ./envs/dev-requirements.txt
       - name: Run tests
         run: python -m pytest --cov --cov-report=xml tests/test_cli.py
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests-python.yml
+++ b/.github/workflows/tests-python.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r ./envs/dev/requirements.txt
+          pip install -r ./envs/requirements.txt
       - name: Run tests
         run: python -m pytest --cov --cov-report=xml tests/test_cli.py
       - name: Upload coverage to Codecov

--- a/envs/dev-requirements.txt
+++ b/envs/dev-requirements.txt
@@ -12,6 +12,8 @@ click==8.1.8
     # via
     #   black
     #   solosis (setup.py)
+colorama==0.4.6
+    # via solosis (logging_utils.py)
 coverage[toml]==7.6.12
     # via pytest-cov
 distlib==0.3.9

--- a/envs/dev-requirements.txt
+++ b/envs/dev-requirements.txt
@@ -12,6 +12,8 @@ click==8.1.8
     # via
     #   black
     #   solosis (setup.py)
+colorama==0.4.6
+    # via solosis (setup.py)
 coverage[toml]==7.6.12
     # via pytest-cov
 distlib==0.3.9

--- a/envs/dev-requirements.txt
+++ b/envs/dev-requirements.txt
@@ -12,8 +12,6 @@ click==8.1.8
     # via
     #   black
     #   solosis (setup.py)
-colorama==0.4.6
-    # via solosis (logging_utils.py)
 coverage[toml]==7.6.12
     # via pytest-cov
 distlib==0.3.9
@@ -30,10 +28,14 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
+numpy==2.2.4
+    # via pandas
 packaging==24.2
     # via
     #   black
     #   pytest
+pandas==2.2.3
+    # via solosis (setup.py)
 pathspec==0.12.1
     # via black
 platformdirs==4.3.6
@@ -53,9 +55,17 @@ pytest-cov==6.0.0
     # via solosis (setup.py)
 pytest-mock==3.14.0
     # via solosis (setup.py)
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.2
+    # via pandas
 pyyaml==6.0.2
     # via pre-commit
+six==1.17.0
+    # via python-dateutil
 tabulate==0.9.0
     # via solosis (setup.py)
+tzdata==2025.2
+    # via pandas
 virtualenv==20.29.2
     # via pre-commit

--- a/envs/doc-requirements.txt
+++ b/envs/doc-requirements.txt
@@ -29,14 +29,24 @@ jinja2==3.1.5
     # via sphinx
 markupsafe==3.0.2
     # via jinja2
+numpy==2.2.4
+    # via pandas
 packaging==24.2
     # via sphinx
+pandas==2.2.3
+    # via solosis (setup.py)
 pygments==2.19.1
     # via sphinx
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.2
+    # via pandas
 requests==2.32.3
     # via sphinx
 roman-numerals-py==3.1.0
     # via sphinx
+six==1.17.0
+    # via python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==8.2.1
@@ -65,5 +75,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 tabulate==0.9.0
     # via solosis (setup.py)
+tzdata==2025.2
+    # via pandas
 urllib3==2.3.0
     # via requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,12 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "black",
+    "colorama",
     "isort",
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-mock",
+    "pytest-mock"
 ]
 doc = [
     "Sphinx",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     extras_require={
         "dev": [
             "black",
+            "colorama",
             "isort",
             "pre-commit",
             "pytest",

--- a/sphinx/development.rst
+++ b/sphinx/development.rst
@@ -25,6 +25,7 @@ Install dev dependencies and install pre-commit hooks
 
 ::
 
+    pip install --upgrade pip
     python -m pip install -r envs/requirements.txt
     python -m pip install -r envs/dev-requirements.txt
     python -m pip install -r envs/doc-requirements.txt


### PR DESCRIPTION
# Pull Request Template

## Summary
Fixing build-docs and deploy-docs PR checks as they are currently failing due to the path to `requirements.txt `was incorrect, this has been updated with this pr.

Fixes #143 

## Changes Made
**List major changes or highlight key points:**
- updated path to` requirements.txt`
- also added path to `doc-requirements.txt` in `build-sphinx.yml`
- also added path to `doc-requirements.txt` in `deploy-sphinx.yml`

I was unsure whether this additional doc-requirements.txt file was needed as previously there was only the path to `./envs/requirements.txt ` however, because of the additional file in the `envs/` I added both files to be installed, hoping that upon review this can be clarified.
Example of yml file (both have had the exact same changes made):
```
- name: Install dependencies
        run: |
          python -m pip install --upgrade pip
          pip install -r ./envs/requirements.txt
          pip install -r ./envs/doc-requirements.txt
```

## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

