### PR TITLE
Add validation for cellranger-count success

### DIFF
--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -65,3 +65,6 @@ cellranger count \
 
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
 echo "Cell Ranger count completed for sample: $SAMPLE_ID"
+
+cd "$OUTPUT_DIR/$SAMPLE_ID" #this ends up being the full output dir e.g. '/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14189565/cellranger/solosis_720/HCA_SkO14189565/'
+grep -q "Pipestance completed successfully!" _log && echo "CellRanger completed successfully for sample: $SAMPLE_ID" || echo "CellRanger failed or incomplete for sample: $SAMPLE_ID."


### PR DESCRIPTION
# Pull Request Template

## Summary
Adds check to `_log` file (part of cellranger output) to validate whether cellranger has run successfully. 

Fixes #112  


## Changes Made
**List major changes or highlight key points:**
- uses `grep` to check for string "Pipestance completed successfully!" in`_log` file of cellranger output and if string is present will print a success message, otherwise prints a failure message. 

This has been done by adding the following to cellranger_count.sh
```
cd "$OUTPUT_DIR/$SAMPLE_ID" #this ends up being the full output dir e.g. '/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14189565/cellranger/solosis_720/HCA_SkO14189565/'
grep -q "Pipestance completed successfully!" _log && echo "CellRanger completed successfully for sample: $SAMPLE_ID" || echo "CellRanger failed or incomplete for sample: $SAMPLE_ID."
```

To test this I ran the above `grep` command on two cellranger outputs-
HCA_SkO1418956 (which successfully completed):
```
/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14189565/cellranger/solosis_720/HCA_SkO14189565$ grep -q "Pipestance completed successfully!" _log && echo "CellRanger completed successfully!" || echo "CellRanger failed or incomplete."
CellRanger completed successfully!
```
then HCA_SkO14542035 (which did not complete successfully):
```
/lustre/scratch126/cellgen/team298/data/samples/HCA_SkO14542035/cellranger/solosis_720/HCA_SkO14542035$ grep -q "Pipestance completed successfully!" _log && echo "CellRanger completed successfully!" || echo "CellRanger failed or incomplete."
CellRanger failed or incomplete.
```

## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

