### PR TITLE
Updating bash script paths for iget-fastqs and cellranger-vdj and farm.py

### DIFF
--- a/solosis/commands/alignment/cellranger_vdj.py
+++ b/solosis/commands/alignment/cellranger_vdj.py
@@ -73,11 +73,9 @@ def cmd(sample, samplefile, version, mem, cpu, queue, debug):
         logger.error(f"No valid samples found. Exiting")
         raise click.Abort()
 
-    cellranger_vdj_path = os.path.abspath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../../../bin/cellranger/cellranger_vdj.sh",
-        )
+    cellranger_vdj_path = os.path.join(
+        os.getenv("SCRIPT_BIN"),
+        "cellranger/cellranger_vdj.sh",
     )
 
     with tempfile.NamedTemporaryFile(

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -63,12 +63,11 @@ def cmd(sample, samplefile, debug):
 
     # Run the metadata script first
     random_id = secrets.token_hex(4)
-    metadata_script = os.path.abspath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../../../bin/irods/nf-irods-to-fastq-metadata.sh",
-        )
+    metadata_script = os.path.join(
+        os.getenv("SCRIPT_BIN"),
+        "irods/nf-irods-to-fastq-metadata.sh",
     )
+
     popen([metadata_script, tmpfile.name, random_id])
 
     # Define expected TSV file path

--- a/solosis/utils/farm.py
+++ b/solosis/utils/farm.py
@@ -133,9 +133,6 @@ def _single_command_bsub(command_to_exec, job_name, queue, time, cores, mem, **k
     Run a single command on the farm.
     """
     # Script directory in the solosis package
-    # script_dir = os.path.dirname(os.path.abspath(__file__))
-    # print(script_dir)
-    # codebase = os.path.join(script_dir, "..", "..", "..", "bin")
     job_runner = os.path.join(os.getenv("SCRIPT_BIN"), "farm/single_job.sh")
     if len(command_to_exec) == 0:
         echo_message("No command to execute", type="error")

--- a/solosis/utils/farm.py
+++ b/solosis/utils/farm.py
@@ -133,10 +133,10 @@ def _single_command_bsub(command_to_exec, job_name, queue, time, cores, mem, **k
     Run a single command on the farm.
     """
     # Script directory in the solosis package
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    print(script_dir)
+    # script_dir = os.path.dirname(os.path.abspath(__file__))
+    # print(script_dir)
     # codebase = os.path.join(script_dir, "..", "..", "..", "bin")
-    job_runner = os.path.abspath(os.path.join(script_dir, "../bin/farm/single_job.sh"))
+    job_runner = os.path.join(os.getenv("SCRIPT_BIN"), "farm/single_job.sh")
     if len(command_to_exec) == 0:
         echo_message("No command to execute", type="error")
         return


### PR DESCRIPTION
# Pull Request Template

## Summary
Updating bash script paths for iget-fastqs and cellranger-vdj, they were outdated compared to changes made in #135 to other command .py scripts. 

## Changes Made
**List major changes or highlight key points:**
- updated path to `nf-irods-to-fastq-metadata.sh` in `iget_fastqs.py`
- updated path to `cellranger_vdj.sh` in `cellranger_vdj.py`
- updated path to `` in `farm.py

example of changes made:
```
cellranger_vdj_path = os.path.join(
        os.getenv("SCRIPT_BIN"),
        "cellranger/cellranger_vdj.sh",
    )
```


## Checklist
- [x] The code adheres to the project's style guidelines
- [x] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


## Additional Information (Optional)
**Include any relevant context, links, or references.**  

