### PR TITLE
Feat/irods archive

### DIFF
--- a/bin/irods/imeta_report.sh
+++ b/bin/irods/imeta_report.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e  
+set -e
 
 if [ -z "$1" ]; then
   echo "No sample ID provided" >&2
@@ -20,8 +20,9 @@ fi
 SAMPLE=$1
 REPORT_PATH=$2
 
-imeta qu -d -z /seq sample = "$SAMPLE" | grep "^collection: " | sed 's/^collection: //' | awk '{print "CRAM," $0}' > "$REPORT_PATH"
-imeta qu -C -z /seq/illumina sample = "$SAMPLE" | grep "^collection: " | sed 's/^collection: //' | awk '{print "CellRanger," $0}' >> "$REPORT_PATH"
+imeta qu -d -z /seq sample = "$SAMPLE" | grep "^collection: " | sed 's/^collection: //' | awk '{print "CRAM," $0}' >"$REPORT_PATH"
+imeta qu -C -z /seq/illumina sample = "$SAMPLE" | grep "^collection: " | sed 's/^collection: //' | awk '{print "COLLECTION," $0}' >>"$REPORT_PATH"
+imeta qu -C -z /archive/team298 sample = "$SAMPLE" | grep "^collection: " | sed 's/^collection: //' | awk '{print "COLLECTION," $0}' >>"$REPORT_PATH"
 echo "Report saved to $REPORT_PATH"
 
 chmod g+w "$REPORT_PATH" >/dev/null 2>&1 || true

--- a/solosis/commands/irods/iget_fastqs.py
+++ b/solosis/commands/irods/iget_fastqs.py
@@ -4,16 +4,19 @@ import secrets
 import tempfile
 
 import click
+import pandas as pd
 
 from solosis.utils.env_utils import irods_auth
 from solosis.utils.input_utils import collect_samples, validate_library_type
 from solosis.utils.logging_utils import debug, log
+from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import logger
 from solosis.utils.subprocess_utils import popen
 
 FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 
 
+@lsf_job(mem=4000, cpu=2, queue="small")
 @click.command("iget-fastqs")
 @click.option("--sample", type=str, help="Sample ID (string)")
 @click.option(
@@ -23,7 +26,7 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 )
 @debug
 @log
-def cmd(sample, samplefile, debug):
+def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
     """Downloads fastqs from iRODS."""
     if debug:
         logger.setLevel(logging.DEBUG)
@@ -62,6 +65,7 @@ def cmd(sample, samplefile, debug):
             tmpfile.write(sample + "\n")
 
     # Run the metadata script first
+    logger.info(f"Looking for data in global archive")
     random_id = secrets.token_hex(4)
     metadata_script = os.path.abspath(
         os.path.join(
@@ -69,7 +73,6 @@ def cmd(sample, samplefile, debug):
             "irods/nf-irods-to-fastq-metadata.sh",
         )
     )
-
     popen([metadata_script, tmpfile.name, random_id])
 
     # Define expected TSV file path
@@ -80,20 +83,66 @@ def cmd(sample, samplefile, debug):
     # Check if metadata TSV file exists
     if not os.path.exists(metadata_tsv_path):
         logger.error(f"Metadata TSV file {metadata_tsv_path} not found.")
-        raise click.Abort()
     else:
         logger.info(f"Metadata TSV file saved: {metadata_tsv_path}")
 
-    # Read and validate TSV file
-    validate_library_type(metadata_tsv_path)
+        # Read and validate TSV file
+        validate_library_type(metadata_tsv_path)
 
-    irods_to_fastq_script = os.path.abspath(
-        os.path.join(
-            os.getenv("SCRIPT_BIN"),
-            "irods/nf-irods-to-fastq.sh",
+        # Run the iRODS to FASTQ script
+        irods_to_fastq_script = os.path.abspath(
+            os.path.join(
+                os.getenv("SCRIPT_BIN"),
+                "irods/nf-irods-to-fastq.sh",
+            )
         )
-    )
-    popen([irods_to_fastq_script, tmpfile.name])
+        popen([irods_to_fastq_script, tmpfile.name])
+
+    logger.info(f"Looking for data in team archive")
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w", suffix=".txt", dir=os.environ["TEAM_TMP_DIR"]
+    ) as tmpfile:
+        logger.debug(f"Temporary command file created: {tmpfile.name}")
+        os.chmod(tmpfile.name, 0o660)
+        for sample in samples_to_download:
+            sample_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample)
+            report_path = os.path.join(sample_dir, "imeta_report.csv")
+            fastq_path = os.path.join(sample_dir, "fastq")
+
+            imeta_report_script = os.path.abspath(
+                os.path.join(
+                    os.getenv("SCRIPT_BIN"),
+                    "irods/imeta_report.sh",
+                )
+            )
+            popen([imeta_report_script, sample, report_path])
+
+            if os.path.exists(report_path):
+                df = pd.read_csv(
+                    report_path, header=None, names=["collection_type", "path"]
+                )
+
+                filtered_df = df[
+                    (df["collection_type"] == "COLLECTION")
+                    & (df["path"].str.startswith("/archive/team298"))
+                ]
+
+                for _, row in filtered_df.iterrows():
+                    path = row["path"]
+                    command = f"iget -r {path} {sample_dir} ; chmod -R g+w {fastq_path} >/dev/null 2>&1 || true"
+                    tmpfile.write(command + "\n")
+                    logger.info(
+                        f'FASTQ files for sample "{sample}" will be downloaded to: {fastq_path}'
+                    )
+
+    if os.path.getsize(tmpfile.name) > 0:
+        submit_lsf_job_array(
+            command_file=tmpfile.name,
+            job_name="iget_fastqs_job_array",
+            cpu=cpu,
+            mem=mem,
+            queue=queue,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR provides support for searching the team298 iRODS archive.

Fixes #44 

## Changes Made
- Updates imeta-report to include collection results from /archive/team298 iRODS zone. 
- Updates iget-fastqs to download collection results from /archive/team298 iRODS zone. 
- Changes the `all-imeta-report.csv` report to include the full list of actual collection paths, instead of the summary, which I think is more useful for the user. 

To test use:
```
./solosis-cli irods imeta-report --sample SIL01
./solosis-cli irods iget-fastqs --sample SIL01
```

Please note, there are not actual FASTQs in the archive yet, but the collections exists and are tagged with metadata, so the Solosis commands will run and give output. 

## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [x] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


