### PR TITLE
Align LSF options

### DIFF
--- a/solosis/commands/alignment/cellranger_arc_count.py
+++ b/solosis/commands/alignment/cellranger_arc_count.py
@@ -6,11 +6,11 @@ import click
 import pandas as pd
 
 from solosis.utils.logging_utils import debug, log
-from solosis.utils.lsf_utils import lsf_options_std, submit_lsf_job_array
+from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import logger
 
 
-@lsf_options_std
+@lsf_job(mem=64000, cpu=4, queue="normal")
 @click.command("cellranger-arc-count")
 @click.option(
     "--libraries", type=click.Path(exists=True), help="Path to a single libraries file"
@@ -34,7 +34,7 @@ from solosis.utils.state import logger
 )
 @debug
 @log
-def cmd(libraries, librariesfile, create_bam, version, mem, cpu, queue, debug):
+def cmd(libraries, librariesfile, create_bam, version, mem, cpu, queue, gpu, debug):
     """Single-cell multiomic data processing"""
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -6,13 +6,13 @@ import click
 
 from solosis.utils.input_utils import collect_samples
 from solosis.utils.logging_utils import debug, log
-from solosis.utils.lsf_utils import lsf_options_std, submit_lsf_job_array
+from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import execution_uid, logger
 
 FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 
 
-@lsf_options_std
+@lsf_job(mem=64000, cpu=4, queue="normal")
 @click.command("cellranger-count")
 @click.option("--sample", type=str, help="Sample ID (string)")
 @click.option(
@@ -34,7 +34,7 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 )
 @debug
 @log
-def cmd(sample, samplefile, create_bam, version, mem, cpu, queue, debug):
+def cmd(sample, samplefile, create_bam, version, mem, cpu, queue, gpu, debug):
     """scRNA-seq mapping and quantification"""
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/solosis/commands/alignment/cellranger_vdj.py
+++ b/solosis/commands/alignment/cellranger_vdj.py
@@ -6,13 +6,13 @@ import click
 
 from solosis.utils.input_utils import collect_samples
 from solosis.utils.logging_utils import debug, log
-from solosis.utils.lsf_utils import lsf_options_std, submit_lsf_job_array
+from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import logger
 
 FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 
 
-@lsf_options_std
+@lsf_job(mem=64000, cpu=4, queue="normal")
 @click.command("cellranger-vdj")
 @click.option("--sample", type=str, help="Sample ID (string)")
 @click.option(
@@ -28,7 +28,7 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 )
 @debug
 @log
-def cmd(sample, samplefile, version, mem, cpu, queue, debug):
+def cmd(sample, samplefile, version, mem, cpu, queue, gpu, debug):
     """immune profiling, scRNA-seq mapping and quantification"""
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -8,12 +8,12 @@ import pandas as pd
 from solosis.utils.env_utils import irods_auth
 from solosis.utils.input_utils import collect_samples
 from solosis.utils.logging_utils import debug, log
-from solosis.utils.lsf_utils import lsf_options_sm, submit_lsf_job_array
+from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import logger
 from solosis.utils.subprocess_utils import popen
 
 
-@lsf_options_sm
+@lsf_job(mem=4000, cpu=2, queue="small")
 @click.command("iget-cellranger")
 @click.option("--sample", type=str, help="Sample ID (string).")
 @click.option(
@@ -23,7 +23,7 @@ from solosis.utils.subprocess_utils import popen
 )
 @debug
 @log
-def cmd(sample, samplefile, mem, cpu, queue, debug):
+def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
     """Downloads cellranger outputs from iRODS."""
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/solosis/utils/lsf_utils.py
+++ b/solosis/utils/lsf_utils.py
@@ -16,32 +16,6 @@ VALID_GPUS = {
 }
 
 
-def lsf_options_sm(function):
-    function = click.option(
-        "--mem", default=4000, type=int, help="Memory limit (in MB)"
-    )(function)
-    function = click.option("--cpu", default=2, type=int, help="Number of CPU cores")(
-        function
-    )
-    function = click.option(
-        "--queue", default="small", help="Queue to which the job should be submitted"
-    )(function)
-    return function
-
-
-def lsf_options_std(function):
-    function = click.option(
-        "--mem", default=64000, type=int, help="Memory limit (in MB)"
-    )(function)
-    function = click.option("--cpu", default=16, type=int, help="Number of CPU cores")(
-        function
-    )
-    function = click.option(
-        "--queue", default="normal", help="Queue to which the job should be submitted"
-    )(function)
-    return function
-
-
 def lsf_job(mem=64000, cpu=2, time="12:00", queue="normal", gpu=None):
     """
     Decorator to add LSF job options to a click command.


### PR DESCRIPTION
## Summary
Align and consolidate the LSF decorator functions.

## Changes Made
- Remove `lsf_options_sm` and `lsf_options_std` to use only `lsf_job`

## Checklist
- [x] The code adheres to the project's style guidelines
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [ ] I have linked this PR to an issue (if applicable)
- [x] I have reviewed my own code for potential issues


