### PR TITLE
Change cellranger-arc output dir

### DIFF
--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -49,12 +49,14 @@ def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
             cellranger_dir = os.path.join(
                 os.getenv("TEAM_SAMPLES_DIR"), sample, "cellranger"
             )
+            os.makedirs(cellranger_dir, exist_ok=True)
+
             cellranger_arc_dir = os.path.join(
                 os.getenv("TEAM_DATA_DIR"), "cellranger-arc"
             )
-            os.makedirs(cellranger_dir, exist_ok=True)
-            report_path = os.path.join(sample_dir, "imeta_report.csv")
+            os.makedirs(cellranger_arc_dir, exist_ok=True)
 
+            report_path = os.path.join(sample_dir, "imeta_report.csv")
             imeta_report_script = os.path.abspath(
                 os.path.join(
                     os.getenv("SCRIPT_BIN"),
@@ -80,12 +82,10 @@ def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
 
                         # @TODO: Properly validate with "analysis_type" metadata attribute
                         if "cellranger-arc" in collection_name:
-                            parent_dir = cellranger_arc_dir
                             output_dir = os.path.join(
                                 cellranger_arc_dir, collection_name
                             )
                         else:
-                            parent_dir = cellranger_dir
                             output_dir = os.path.join(cellranger_dir, collection_name)
 
                         if (
@@ -99,7 +99,7 @@ def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
                             continue
 
                         samples_to_download.append((sample, output_dir))
-                        command = f"iget -r {path} {parent_dir} ; chmod -R g+w {parent_dir} >/dev/null 2>&1 || true"
+                        command = f"iget -r {path} {output_dir} ; chmod -R g+w {output_dir} >/dev/null 2>&1 || true"
                         tmpfile.write(command + "\n")
                         logger.info(
                             f'Collection "{collection_name}" for sample "{sample}" will be downloaded to: {output_dir}'

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -49,6 +49,9 @@ def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
             cellranger_dir = os.path.join(
                 os.getenv("TEAM_SAMPLES_DIR"), sample, "cellranger"
             )
+            cellranger_arc_dir = os.path.join(
+                os.getenv("TEAM_DATA_DIR"), "cellranger-arc"
+            )
             os.makedirs(cellranger_dir, exist_ok=True)
             report_path = os.path.join(sample_dir, "imeta_report.csv")
 
@@ -74,19 +77,29 @@ def cmd(sample, samplefile, mem, cpu, queue, gpu, debug):
                                 f"Could not determine collection name {path}"
                             )
                             continue
-                        output_dir = os.path.join(cellranger_dir, collection_name)
+
+                        # @TODO: Properly validate with "analysis_type" metadata attribute
+                        if "cellranger-arc" in collection_name:
+                            parent_dir = cellranger_arc_dir
+                            output_dir = os.path.join(
+                                cellranger_arc_dir, collection_name
+                            )
+                        else:
+                            parent_dir = cellranger_dir
+                            output_dir = os.path.join(cellranger_dir, collection_name)
+
                         if (
                             os.path.exists(output_dir)
                             and os.path.isdir(output_dir)
                             and os.listdir(output_dir)
                         ):
                             logger.warning(
-                                f"Skipping {collection_name}, already exists in {cellranger_dir}"
+                                f"Skipping {collection_name}, already exists in {output_dir}"
                             )
                             continue
 
                         samples_to_download.append((sample, output_dir))
-                        command = f"iget -r {path} {cellranger_dir} ; chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true"
+                        command = f"iget -r {path} {parent_dir} ; chmod -R g+w {parent_dir} >/dev/null 2>&1 || true"
                         tmpfile.write(command + "\n")
                         logger.info(
                             f'Collection "{collection_name}" for sample "{sample}" will be downloaded to: {output_dir}'


### PR DESCRIPTION
# Description

When pulling data from iRODS associated with cellranger-arc output, it doens't belong to a single sample, so it shouldn't be stored in the samples directory. Instead it should be saved in the `/data/cellranger-arc/` directory. This replicates the same approach to us generating our own cellranger-arc output. 

Fixes #97

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
