### PR TITLE
Add --chemistry flag to cellranger-count command 

### DIFF
--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -12,9 +12,9 @@
 #   <cpu>         - Number of CPU cores.
 #   <mem>         - Memory in MB.
 #   --no-bam      - Optional flag to disable BAM file generation.
-#   --chemistry <value> - Chemistry of assay kit used.
+#   --chemistry <value> - Optional chemistry of assay kit used.
 
-set -e  # Exit immediately if a command fails
+set -e # Exit immediately if a command fails
 
 # Check if at least 6 arguments are provided
 if [ "$#" -lt 6 ]; then
@@ -23,7 +23,6 @@ if [ "$#" -lt 6 ]; then
 fi
 
 # Assign command-line arguments to variables
-# Assign required arguments
 SAMPLE_ID="$1"
 OUTPUT_DIR="$2"
 FASTQ_DIR="$3"
@@ -33,7 +32,7 @@ MEM="$6"
 # Initialize optional flags
 BAM_FLAG=""  # Default to generating BAM files
 CHEMISTRY="" # Default should detect chemistry
-# Define reference 
+# Define reference
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 echo "Arguments received: $@"
 
@@ -61,15 +60,6 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-# Handle optional --no-bam flag (disables BAM file generation)
-#if [ "$7" == "--no-bam" ]; then
-#  BAM_FLAG="--no-bam"
-#fi
-# Handle optional --chemistry flag (default is not needed)
-#if [ "$8" == "--chemistry" ] && [ -n "$9" ]; then
-#  CHEMISTRY="--chemistry=$9"
-#fi
-
 # Load Cell Ranger ARC module (make sure the version is correct)
 if ! module load cellgen/cellranger/"$VERSION"; then
   echo "Failed to load Cell Ranger version $VERSION" >&2
@@ -91,22 +81,21 @@ echo "Using $CPU CPU cores and $(($MEM / 1000)) GB memory"
 
 # Run Cell Ranger count
 cellranger count \
-    --id="$SAMPLE_ID" \
-    --fastqs="$FASTQ_DIR" \
-    --transcriptome="$REF" \
-    --sample="$SAMPLE_ID" \
-    --localcores="$CPU" \
-    --localmem="$(($MEM / 1000))" \
-    $BAM_FLAG \
-    $CHEMISTRY
-
+  --id="$SAMPLE_ID" \
+  --fastqs="$FASTQ_DIR" \
+  --transcriptome="$REF" \
+  --sample="$SAMPLE_ID" \
+  --localcores="$CPU" \
+  --localmem="$(($MEM / 1000))" \
+  $BAM_FLAG \
+  "$CHEMISTRY"
 
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
 echo "Cell Ranger count completed for sample: $SAMPLE_ID"
 
 log_file="$OUTPUT_DIR/$SAMPLE_ID/_log"
 if grep -q "Pipestance completed successfully!" "$log_file"; then
-    echo "CellRanger completed successfully for sample: $SAMPLE_ID"
+  echo "CellRanger completed successfully for sample: $SAMPLE_ID"
 else
-    echo "CellRanger incomplete or not found for sample: $SAMPLE_ID."
+  echo "CellRanger incomplete or not found for sample: $SAMPLE_ID."
 fi

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -32,7 +32,7 @@ MEM="$6"
 BAM_FLAG=""  # Default to generating BAM files
 CHEMISTRY="" # Default should detect chemistry
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
-
+echo "Arguments received: $@"
 # Handle optional --no-bam flag (disables BAM file generation)
 if [ "$7" == "--no-bam" ]; then
   BAM_FLAG="--no-bam"

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -2,7 +2,7 @@
 # cellranger_count.sh - Run Cell Ranger count for a given sample
 
 # Usage:
-#   ./cellranger_count.sh <sample_id> <output_dir> <fastq_dir> <version> <cpu> <mem> [--no-bam] [--chemistry]
+#   ./cellranger_count.sh <sample_id> <output_dir> <fastq_dir> <version> <cpu> <mem> [--no-bam] [--chemistry <str>]
 #
 # Parameters:
 #   <sample_id>   - Sample ID to process.
@@ -12,7 +12,7 @@
 #   <cpu>         - Number of CPU cores.
 #   <mem>         - Memory in MB.
 #   --no-bam      - Optional flag to disable BAM file generation.
-#   --chemistry   - Chemistry of assay kit used.
+#   --chemistry <value> - Chemistry of assay kit used.
 
 set -e  # Exit immediately if a command fails
 
@@ -29,19 +29,41 @@ FASTQ_DIR="$3"
 VERSION="$4"
 CPU="$5"
 MEM="$6"
+
+# optional variables
 BAM_FLAG=""  # Default to generating BAM files
 CHEMISTRY="" # Default should detect chemistry
+
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 echo "Arguments received: $@"
 # Handle optional --no-bam flag (disables BAM file generation)
-if [ "$7" == "--no-bam" ]; then
-  BAM_FLAG="--no-bam"
-fi
+#if [ "$7" == "--no-bam" ]; then
+#  BAM_FLAG="--no-bam"
+#fi
 
-# Handle optional --chemistry flag (default is not needed)
-if [ "$8" == "--chemistry" ] && [ -n "$9" ]; then
-  CHEMISTRY="--chemistry=$9"
-fi
+# Parse optional flags
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --no-bam)
+      BAM_FLAG="--no-bam"
+      shift
+      ;;
+    --chemistry)
+      CHEMISTRY_VALUE="$2"
+      if [ -z "$CHEMISTRY_VALUE" ]; then
+        echo "Error: --chemistry flag requires a value." >&2
+        exit 1
+      fi
+      CHEMISTRY="--chemistry=$CHEMISTRY_VALUE"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $key" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # Load Cell Ranger ARC module (make sure the version is correct)
 if ! module load cellgen/cellranger/"$VERSION"; then

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -29,41 +29,19 @@ FASTQ_DIR="$3"
 VERSION="$4"
 CPU="$5"
 MEM="$6"
-
-# optional variables
 BAM_FLAG=""  # Default to generating BAM files
 CHEMISTRY="" # Default should detect chemistry
-
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 echo "Arguments received: $@"
 # Handle optional --no-bam flag (disables BAM file generation)
-#if [ "$7" == "--no-bam" ]; then
-#  BAM_FLAG="--no-bam"
-#fi
+if [ "$7" == "--no-bam" ]; then
+  BAM_FLAG="--no-bam"
+fi
 
-# Parse optional flags
-while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    --no-bam)
-      BAM_FLAG="--no-bam"
-      shift
-      ;;
-    --chemistry)
-      CHEMISTRY_VALUE="$2"
-      if [ -z "$CHEMISTRY_VALUE" ]; then
-        echo "Error: --chemistry flag requires a value." >&2
-        exit 1
-      fi
-      CHEMISTRY="--chemistry=$CHEMISTRY_VALUE"
-      shift 2
-      ;;
-    *)
-      echo "Unknown option: $key" >&2
-      exit 1
-      ;;
-  esac
-done
+# Handle optional --chemistry flag (default is not needed)
+if [ "$8" == "--chemistry" ] && [ -n "$9" ]; then
+  CHEMISTRY="--chemistry=$9"
+fi
 
 # Load Cell Ranger ARC module (make sure the version is correct)
 if ! module load cellgen/cellranger/"$VERSION"; then

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -2,7 +2,7 @@
 # cellranger_count.sh - Run Cell Ranger count for a given sample
 
 # Usage:
-#   ./cellranger_count.sh <sample_id> <output_dir> <fastq_dir> <version> <cpu> <mem> [--no-bam]
+#   ./cellranger_count.sh <sample_id> <output_dir> <fastq_dir> <version> <cpu> <mem> [--no-bam] [--chemistry]
 #
 # Parameters:
 #   <sample_id>   - Sample ID to process.
@@ -12,12 +12,13 @@
 #   <cpu>         - Number of CPU cores.
 #   <mem>         - Memory in MB.
 #   --no-bam      - Optional flag to disable BAM file generation.
+#   --chemistry   - Chemistry of assay kit used.
 
 set -e  # Exit immediately if a command fails
 
 # Check if at least 6 arguments are provided
 if [ "$#" -lt 6 ]; then
-  echo "Usage: $0 <sample_id> <output_dir> <fastq_dir> <version> <cpu> <mem> [--no-bam]" >&2
+  echo "Usage: $0 <sample_id> <output_dir> <fastq_dir> <version> <cpu> <mem> [--no-bam] [--chemistry]" >&2
   exit 1
 fi
 
@@ -29,11 +30,17 @@ VERSION="$4"
 CPU="$5"
 MEM="$6"
 BAM_FLAG=""  # Default to generating BAM files
+CHEMISTRY="" # Default should detect chemistry
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 
 # Handle optional --no-bam flag (disables BAM file generation)
 if [ "$7" == "--no-bam" ]; then
   BAM_FLAG="--no-bam"
+fi
+
+# Handle optional --chemistry flag (default is not needed)
+if [ "$8" == "--chemistry" ] && [ -n "$9" ]; then
+  CHEMISTRY="--chemistry=$9"
 fi
 
 # Load Cell Ranger ARC module (make sure the version is correct)
@@ -61,7 +68,9 @@ cellranger count \
     --sample="$SAMPLE_ID" \
     --localcores="$CPU" \
     --localmem="$(($MEM / 1000))" \
-    $BAM_FLAG
+    $BAM_FLAG \
+    $CHEMISTRY
+
 
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
 echo "Cell Ranger count completed for sample: $SAMPLE_ID"

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -38,7 +38,7 @@ REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 echo "Arguments received: $@"
 
 # Parse optional arguments
-shift 2
+shift 6
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
   --chemistry)

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -27,6 +27,27 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
     help="Generate BAM files for each sample",
 )
 @click.option(
+    "--chemistry",
+    type=click.Choice(
+        [
+            "SC5P-R2",
+            "SC5P-PE-v3",
+            "SC5P-R2",
+            "SC5P-R2-v3",
+            "SC3Pv1",
+            "SC3Pv2",
+            "SC3Pv3",
+            "SC3Pv4",
+            "SC3Pv3LT",
+            "SC3Pv3HT",
+            "SFRP",
+            "MFRP",
+        ]
+    ),
+    # type=str,
+    help="Chemistry assay to define",
+)
+@click.option(
     "--version",
     type=str,
     default="7.2.0",
@@ -34,7 +55,9 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 )
 @debug
 @log
-def cmd(sample, samplefile, create_bam, version, mem, cpu, queue, gpu, debug):
+def cmd(
+    sample, samplefile, create_bam, chemistry, version, mem, cpu, queue, gpu, debug
+):
     """scRNA-seq mapping and quantification"""
     if debug:
         logger.setLevel(logging.DEBUG)
@@ -123,10 +146,12 @@ def cmd(sample, samplefile, create_bam, version, mem, cpu, queue, gpu, debug):
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
         for sample in valid_samples:
-            command = f"{cellranger_count_path} {sample['sample_id']} {sample['output_dir']} {sample['fastq_dir']} {version} {cpu} {mem}"
+            command = f"{cellranger_count_path} {sample['sample_id']} {sample['output_dir']} {sample['fastq_dir']} {chemistry} {version} {cpu} {mem}"
             if not create_bam:
                 command += " --no-bam"
             tmpfile.write(command + "\n")
+            if chemistry:
+                command += ["--chemistry", chemistry]
 
     submit_lsf_job_array(
         command_file=tmpfile.name,

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -150,7 +150,7 @@ def cmd(
             if not create_bam:
                 command += " --no-bam"
             tmpfile.write(command + "\n")
-            if chemistry:
+            if chemistry is not None and chemistry != 0:
                 command += f" --chemistry {chemistry}"
 
     submit_lsf_job_array(

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -146,7 +146,7 @@ def cmd(
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
         for sample in valid_samples:
-            command = f"{cellranger_count_path} {sample['sample_id']} {sample['output_dir']} {sample['fastq_dir']} {chemistry} {version} {cpu} {mem}"
+            command = f"{cellranger_count_path} {sample['sample_id']} {sample['output_dir']} {sample['fastq_dir']} {version} {cpu} {mem}"
             if not create_bam:
                 command += " --no-bam"
             tmpfile.write(command + "\n")

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -28,23 +28,23 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 )
 @click.option(
     "--chemistry",
-    # type=click.Choice(
-    #    [
-    #        "SC5P-R2",
-    #        "SC5P-PE-v3",
-    #        "SC5P-R2",
-    #        "SC5P-R2-v3",
-    #        "SC3Pv1",
-    #        "SC3Pv3",
-    #        "SC3Pv2",
-    #        "SC3Pv4",
-    #        "SC3Pv3LT",
-    #        "SC3Pv3HT",
-    #        "SFRP",
-    #        "MFRP",
-    #    ]
-    # ),
-    type=str,
+    type=click.Choice(
+        [
+            "SC5P-R2",
+            "SC5P-PE-v3",
+            "SC5P-R2",
+            "SC5P-R2-v3",
+            "SC3Pv1",
+            "SC3Pv3",
+            "SC3Pv2",
+            "SC3Pv4",
+            "SC3Pv3LT",
+            "SC3Pv3HT",
+            "SFRP",
+            "MFRP",
+        ]
+    ),
+    # type=str,
     help="Chemistry assay to define",
 )
 @click.option(
@@ -149,9 +149,9 @@ def cmd(
             command = f"{cellranger_count_path} {sample['sample_id']} {sample['output_dir']} {sample['fastq_dir']} {version} {cpu} {mem}"
             if not create_bam:
                 command += " --no-bam"
-            tmpfile.write(command + "\n")
-            if chemistry is not None and chemistry != 0:
+            if chemistry:
                 command += f" --chemistry {chemistry}"
+            tmpfile.write(command + "\n")
 
     submit_lsf_job_array(
         command_file=tmpfile.name,

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -28,23 +28,23 @@ FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 )
 @click.option(
     "--chemistry",
-    type=click.Choice(
-        [
-            "SC5P-R2",
-            "SC5P-PE-v3",
-            "SC5P-R2",
-            "SC5P-R2-v3",
-            "SC3Pv1",
-            "SC3Pv2",
-            "SC3Pv3",
-            "SC3Pv4",
-            "SC3Pv3LT",
-            "SC3Pv3HT",
-            "SFRP",
-            "MFRP",
-        ]
-    ),
-    # type=str,
+    # type=click.Choice(
+    #    [
+    #        "SC5P-R2",
+    #        "SC5P-PE-v3",
+    #        "SC5P-R2",
+    #        "SC5P-R2-v3",
+    #        "SC3Pv1",
+    #        "SC3Pv3",
+    #        "SC3Pv2",
+    #        "SC3Pv4",
+    #        "SC3Pv3LT",
+    #        "SC3Pv3HT",
+    #        "SFRP",
+    #        "MFRP",
+    #    ]
+    # ),
+    type=str,
     help="Chemistry assay to define",
 )
 @click.option(

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -151,7 +151,7 @@ def cmd(
                 command += " --no-bam"
             tmpfile.write(command + "\n")
             if chemistry:
-                command += ["--chemistry", chemistry]
+                command += f" --chemistry {chemistry}"
 
     submit_lsf_job_array(
         command_file=tmpfile.name,


### PR DESCRIPTION
# Description

Added `--chemistry` flag to cellranger-count command as an optional flag. used `click.Choice()` (see line31) to define all available chemistry assays to ensure correct. List of assays availble using `--help`:
```
./solosis-cli alignment cellranger-count --help
--chemistry [SC5P-R2|SC5P-PE-v3|SC5P-R2|SC5P-R2-v3|SC3Pv1|SC3Pv3|SC3Pv2|SC3Pv4|SC3Pv3LT|SC3Pv3HT|SFRP|MFRP]
                                  Chemistry assay to define
```


Fixes #163 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
