### PR TITLE
Bugfix/teamdatadir path

### DIFF
--- a/bin/farm/submit_file.sh
+++ b/bin/farm/submit_file.sh
@@ -39,7 +39,7 @@ if ! module load cellgen/cellranger/"$VERSION"; then
 fi
 
 # Configure paths and job parameters
-TEAM_SAMPLE_DATA_DIR="/lustre/scratch126/cellgen/team298/data/samples"
+TEAM_SAMPLE_DATA_DIR="/lustre/scratch124/cellgen/haniffa/data/samples"
 TEAM_LOGS_DIR="$HOME/logs"
 CPU=16
 MEM=64000

--- a/bin/scrna/merge-h5ad/submit.sh
+++ b/bin/scrna/merge-h5ad/submit.sh
@@ -23,7 +23,7 @@ merged_filename=$1; shift
 #mkdir -p pap
 
 HL_HIST_FOLDER=".pap"
-target_dir=/lustre/scratch126/cellgen/team298/sample_data/ # This is obtained by module load hl
+target_dir=/lustre/scratch124/cellgen/haniffa/sample_data/ # This is obtained by module load hl
 cwd=`pwd`
 run_token=$RUN_TOKEN
 outpt_prefix=`echo $merged_filename | sed -e 's/.h5ad//g'`

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -5,7 +5,7 @@ conda_env="/software/cellgen/team298/shared/envs/hlb-conda/rna"
 if [ $# -ne 2 ]; then
 	echo "$0 samples_database sample_sheet.tsv"
 	echo "This is a follow up of irods/pull-processed. If you have not run it, do so"
-	echo "samples_database: Folder where you have all sample cellranger data. Ideally - /lustre/scratch126/cellgen/team298/data/samples"
+	echo "samples_database: Folder where you have all sample cellranger data. Ideally - /lustre/scratch124/cellgen/haniffa/data/samples"
 	echo "sample_name: Folder name of sample that contains the processed_sanger folder"
 	exit 0
 fi

--- a/modulefiles/solosis/0.4.2
+++ b/modulefiles/solosis/0.4.2
@@ -23,7 +23,7 @@ if {![info exists env(LSB_DEFAULT_USERGROUP)]} {
 }
 
 setenv SOLOSIS_BASE /software/cellgen/team298/shared/solosis/0.4.2
-setenv TEAM_DATA_DIR /lustre/scratch126/cellgen/$env(LSB_DEFAULT_USERGROUP)/data
+setenv TEAM_DATA_DIR /lustre/scratch126/cellgen/haniffa/data
 
 prepend-path PATH $env(SOLOSIS_BASE)
 

--- a/modulefiles/solosis/0.4.2
+++ b/modulefiles/solosis/0.4.2
@@ -23,7 +23,7 @@ if {![info exists env(LSB_DEFAULT_USERGROUP)]} {
 }
 
 setenv SOLOSIS_BASE /software/cellgen/team298/shared/solosis/0.4.2
-setenv TEAM_DATA_DIR /lustre/scratch126/cellgen/haniffa/data
+setenv TEAM_DATA_DIR /lustre/scratch124/cellgen/haniffa/data
 
 prepend-path PATH $env(SOLOSIS_BASE)
 

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -12,7 +12,7 @@ from solosis.utils.farm import echo_message, irods_validation, log_command
 @click.option(
     "--sample_basedir",
     required=False,
-    default="/lustre/scratch126/cellgen/team298/sample_data/",
+    default="/lustre/scratch124/cellgen/haniffa/sample_data/",
     help="sample database folder",
 )
 @click.pass_context

--- a/sphinx/development.rst
+++ b/sphinx/development.rst
@@ -42,8 +42,8 @@ Then create the directory
 ::
 
     export export LSB_DEFAULT_USERGROUP=<USERGROUP>
-    export TEAM_DATA_DIR=/lustre/scratch126/cellgen/haniffa/data
-    export TEAM_LOGS_DIR=/lustre/scratch126/cellgen/team298/logs
+    export TEAM_DATA_DIR=/lustre/scratch124/cellgen/haniffa/data
+    export TEAM_LOGS_DIR=/lustre/scratch124/cellgen/haniffa/logs
 
 5. **Set-up new git branch**
 

--- a/sphinx/development.rst
+++ b/sphinx/development.rst
@@ -42,7 +42,7 @@ Then create the directory
 ::
 
     export export LSB_DEFAULT_USERGROUP=<USERGROUP>
-    export TEAM_DATA_DIR=/lustre/scratch126/cellgen/team298/data
+    export TEAM_DATA_DIR=/lustre/scratch126/cellgen/haniffa/data
     export TEAM_LOGS_DIR=/lustre/scratch126/cellgen/team298/logs
 
 5. **Set-up new git branch**


### PR DESCRIPTION
# Description

Updating variable `TEAM_SAMPLE_DATA_DIR` and `TEAM_DATA_DIR` to match new Lustre paths.

Fixes #176 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
