### PR TITLE
Opt/cellranger default long

### DIFF
--- a/solosis/commands/alignment/cellranger_arc_count.py
+++ b/solosis/commands/alignment/cellranger_arc_count.py
@@ -132,7 +132,7 @@ def cmd(libraries, librariesfile, create_bam, version, mem, cpu, queue, gpu, deb
         job_name="cellranger_arc_count_job_array",
         cpu=cpu,
         mem=mem,
-        queue=queue,
+        queue="long",
         gpu=gpu,
     )
 

--- a/solosis/commands/alignment/cellranger_arc_count.py
+++ b/solosis/commands/alignment/cellranger_arc_count.py
@@ -10,7 +10,7 @@ from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import logger
 
 
-@lsf_job(mem=64000, cpu=4, queue="normal")
+@lsf_job(mem=64000, cpu=4, queue="long")
 @click.command("cellranger-arc-count")
 @click.option(
     "--libraries", type=click.Path(exists=True), help="Path to a single libraries file"
@@ -132,7 +132,7 @@ def cmd(libraries, librariesfile, create_bam, version, mem, cpu, queue, gpu, deb
         job_name="cellranger_arc_count_job_array",
         cpu=cpu,
         mem=mem,
-        queue="long",
+        queue=queue,
         gpu=gpu,
     )
 

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -12,7 +12,7 @@ from solosis.utils.state import execution_uid, logger
 FASTQ_EXTENSIONS = [".fastq", ".fastq.gz"]
 
 
-@lsf_job(mem=64000, cpu=4, queue="normal")
+@lsf_job(mem=64000, cpu=4, queue="long")
 @click.command("cellranger-count")
 @click.option("--sample", type=str, help="Sample ID (string)")
 @click.option(
@@ -133,7 +133,7 @@ def cmd(sample, samplefile, create_bam, version, mem, cpu, queue, gpu, debug):
         job_name="cellranger_count_job_array",
         cpu=cpu,
         mem=mem,
-        queue="long",
+        queue=queue,
         gpu=gpu,
     )
 

--- a/solosis/commands/alignment/cellranger_count.py
+++ b/solosis/commands/alignment/cellranger_count.py
@@ -133,7 +133,7 @@ def cmd(sample, samplefile, create_bam, version, mem, cpu, queue, gpu, debug):
         job_name="cellranger_count_job_array",
         cpu=cpu,
         mem=mem,
-        queue=queue,
+        queue="long",
         gpu=gpu,
     )
 


### PR DESCRIPTION
# Description

Changed the cellranger-count and cellranger arc jobs to be submitted into the long queue by default rather than normal queue. Confirmed by submitting jobs on farm 

example:
```
$ ./solosis-cli alignment cellranger-count --sample HCA_SkO14189565
  SOLOSIS    ~  version 0.4.2
INFO: Initialized with execution_uid: 0f24e5d1-2bc4-4281-bd20-5bd35663ecc8
INFO: Job submitted successfully: Job <114820> is submitted to queue <long>.
lg28@farm22-head2:~/repos/solosis$ bjobs
JOBID   USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
114820  lg28    RUN   long       farm22-head node-13-22  *_array[1] Aug  8 16:45
                                             node-13-22
                                             node-13-22
                                             node-13-22
```

Fixes #173 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
