### PR TITLE
Feat/download specific iget cellranger

### DIFF
--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -55,10 +55,12 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
         for sample in samples:
-            sample_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample)
+            sample_dir = os.path.join(
+                os.getenv("TEAM_SAMPLES_DIR"), sample["sample_id"]
+            )
             sample_id = sample["sample_id"]
             cellranger_dir = os.path.join(
-                os.getenv("TEAM_SAMPLES_DIR"), sample, "cellranger"
+                os.getenv("TEAM_SAMPLES_DIR"), sample_id, "cellranger"
             )
             os.makedirs(cellranger_dir, exist_ok=True)
             report_path = os.path.join(sample_dir, "imeta_report.csv")

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -94,7 +94,9 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                             f"Could not determine collection name from path: {path}"
                         )
                         continue
-                    output_dir = os.path.join(cellranger_dir, collection_name)
+                    output_dir = os.path.join(
+                        os.getenv("TEAM_SAMPLES_DIR"), sample_id, "cellranger"
+                    )
                     if (
                         os.path.exists(output_dir)
                         and os.path.isdir(output_dir)

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -60,8 +60,11 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
             sample_id = sample["sample_id"]
             if "cellranger_dir" in sample:
                 # Already provided path
-                cellranger_dir = sample["cellranger_dir"]
-                sample_dir = cellranger_dir  # For locating imeta_report.csv
+                # irods_path = sample["cellranger_dir"]
+                sample_dir = os.path.join(
+                    os.getenv("TEAM_SAMPLES_DIR"), sample_id
+                )  # For locating imeta_report.csv
+                cellranger_dir = os.path.join(sample_dir, "cellranger")
             else:
                 # Construct paths from sample ID
                 sample_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -23,12 +23,6 @@ from solosis.utils.subprocess_utils import popen
     type=click.Path(exists=True),
     help="Path to a CSV or TSV file containing sample IDs.",
 )
-# add in metadata flag
-@click.option(
-    "--metadata",
-    type=click.Path(exists=True),
-    help="Path to a CSV or TSV file containing metadata",
-)
 @debug
 @log
 def cmd(sample, samplefile, mem, cpu, queue, debug):

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -8,7 +8,7 @@ import pandas as pd
 from solosis.utils.env_utils import irods_auth
 
 # from solosis.utils.input_utils import collect_samples
-from solosis.utils.input_utils import process_metadata_file
+from solosis.utils.input_utils import collect_samples, process_metadata_file
 from solosis.utils.logging_utils import debug, log
 from solosis.utils.lsf_utils import lsf_options_sm, submit_lsf_job_array
 from solosis.utils.state import logger
@@ -40,8 +40,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
 
     samples_to_download = []
 
-    #
-    df = pd.read_csv(samplefile, sep=sep)
+    df = pd.read_csv(samplefile)
     cols = set(df.columns)
     # if using samplefile has 'cellranger_dir' column use collect_samples()
     # if using samplefile doesn't have 'cellranger_dir' column use process_metadata_file()

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -22,7 +22,7 @@ from solosis.utils.subprocess_utils import popen
 )
 @debug
 @log
-def cmd(sample, samplefile, mem, cpu, queue, debug):
+def cmd(samplefile, mem, cpu, queue, debug):
     """Downloads cellranger outputs from iRODS."""
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -71,7 +71,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                     "irods/imeta_report.sh",
                 )
             )
-            popen([imeta_report_script, sample, report_path])
+            popen([imeta_report_script, sample_id, report_path])
 
             if os.path.exists(report_path):
                 df = pd.read_csv(
@@ -98,7 +98,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                             )
                             continue
 
-                        samples_to_download.append((sample, output_dir))
+                        samples_to_download.append((sample_id, output_dir))
                         for _, row in df.iterrows():
                             sample = row["sample_id"]  # Get the sample ID for this row
                             output_dir = os.path.join(
@@ -116,7 +116,7 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
                         # command = f"iget -r {path} {cellranger_dir} ; chmod -R g+w {cellranger_dir} >/dev/null 2>&1 || true"
                         tmpfile.write(command + "\n")
                         logger.info(
-                            f'Collection "{collection_name}" for sample "{sample}" will be downloaded to: {output_dir}'
+                            f'Collection "{collection_name}" for sample "{sample_id}" will be downloaded to: {output_dir}'
                         )
 
     submit_lsf_job_array(

--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -58,17 +58,10 @@ def cmd(sample, samplefile, mem, cpu, queue, debug):
         os.chmod(tmpfile.name, 0o660)
         for sample in samples:
             sample_id = sample["sample_id"]
-            if "cellranger_dir" in sample:
-                # Already provided path
-                # irods_path = sample["cellranger_dir"]
-                sample_dir = os.path.join(
-                    os.getenv("TEAM_SAMPLES_DIR"), sample_id
-                )  # For locating imeta_report.csv
-                cellranger_dir = os.path.join(sample_dir, "cellranger")
-            else:
-                # Construct paths from sample ID
-                sample_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
-                cellranger_dir = os.path.join(sample_dir, "cellranger")
+            sample_dir = os.path.join(
+                os.getenv("TEAM_SAMPLES_DIR"), sample_id
+            )  # For locating imeta_report.csv
+            cellranger_dir = os.path.join(sample_dir, "cellranger")
 
             os.makedirs(cellranger_dir, exist_ok=True)
             report_path = os.path.join(sample_dir, "imeta_report.csv")


### PR DESCRIPTION
# Description

making sure irods_path is specified for each sample before downloading.

Checking the validation..
with cellranger_dir as column name instead of irods_path
```
$ ./solosis-cli irods iget-cellranger --samplefile ../../sol_in_crdwnld.csv
  SOLOSIS    ~  version 0.4.0
INFO: Initialized with execution_uid: 173c7537-1310-4e44-a2c1-6c2c9feae2c4
INFO: Checking iRODS authentication status...
INFO: iRODS authenticated
WARNING: samplefile file ../../sol_in_crdwnld.csv is missing required columns: irods_path
ERROR: No samples provided. Use --samplefile
Aborted!
```
with incorrect irods_path 
```
lg28@farm22-head2:~/repos/solosis$ ./solosis-cli irods iget-cellranger --samplefile ../../sol_in_crdwnld.csv
  SOLOSIS    ~  version 0.4.0
INFO: Initialized with execution_uid: da7de37d-eac3-4689-97f2-5cfca98b92e3
INFO: Checking iRODS authentication status...
INFO: iRODS authenticated
ERROR: Provided iRODS path '/lustre/scratch124/cellgen/haniffa/data/samples/HCA_SkO14542035/cellranger/cellranger700_count_48214_HCA_SkO14542035_GRCh38-2020-A/' does not match any known collections for sample_id 'HCA_SkO14542035'.
Aborted!
```
with correct irods_path column and correct irods_paths
```
$ ./solosis-cli irods iget-cellranger --samplefile ../../sol_in_crdwnld.csv
  SOLOSIS    ~  version 0.4.0
INFO: Initialized with execution_uid: 4e47f746-8dd0-4b2b-a5df-0d69a8a56a52
INFO: Checking iRODS authentication status...
INFO: iRODS authenticated
INFO: Collection "/seq/illumina/runs/48/48282/cellranger/cellranger700_count_48282_HCA_SkO14542035_GRCh38-2020-A" for sample "HCA_SkO14542035" will be downloaded to: /lustre/scratch124/cellgen/haniffa/data/samples/HCA_SkO14542035/cellranger
INFO: Collection "/seq/illumina/runs/48/48282/cellranger/cellranger700_count_48282_HCA_SkO14542036_GRCh38-2020-A" for sample "HCA_SkO14542036" will be downloaded to: /lustre/scratch124/cellgen/haniffa/data/samples/HCA_SkO14542036/cellranger
INFO: Job submitted successfully: Job <787379> is submitted to queue <small>.
INFO: Log file of output paths: /nfs/users/nfs_l/lg28/repos/solosis/iget-cellranger.log
```


Fixes # 137

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
