### PR TITLE
removing sanger paths for sphinx docs #179

### DIFF
--- a/sphinx/development.rst
+++ b/sphinx/development.rst
@@ -21,7 +21,7 @@ Ensure you are in your home directory
 .. code-block:: shell
    :caption: Expected Output
 
-   /nfs/users/nfs_l/<USER>
+   $HOME/<USER>
 
 Then create the directory 
 ::
@@ -42,8 +42,9 @@ Then create the directory
 ::
 
     export export LSB_DEFAULT_USERGROUP=<USERGROUP>
-    export TEAM_DATA_DIR=/lustre/scratch126/cellgen/team298/data
-    export TEAM_LOGS_DIR=/lustre/scratch126/cellgen/team298/logs
+    export TEAM_DATA_DIR=./data
+    export TEAM_SAMPLE_DATA_DIR=./data/samples
+    export TEAM_LOGS_DIR=./logs
 
 5. **Set-up new git branch**
 


### PR DESCRIPTION
# Description

- Created new solosis docs on Notion (found in wiki page) https://www.notion.so/haniffalab/Solosis-86fec351478140b6b75e375cafccfaaf
- removed Sanger paths from sphinx docs

Fixes #179 

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
