### PR TITLE
Bugfix- making cellranger 9.0.1 available in solosis 

### DIFF
--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -82,7 +82,7 @@ echo "Total droplets: ${TOTAL_DROPLETS_FLAG:-Auto-detected}"
 echo "Expected cells: ${EXPECTED_CELLS_FLAG:-Auto-detected}"
 
 # Construct command
-CELLBENDER_CMD=("cellbender" "remove-background"
+CELLBENDER_CMD=("cellbender remove-background"
   "--input=$CELLRANGER_DIR/raw_feature_bc_matrix.h5"
   "--output=$OUTPUT_DIR/${SAMPLE_ID}_${USER}_$(date +%Y%m%d).h5"
 )

--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -82,7 +82,7 @@ echo "Total droplets: ${TOTAL_DROPLETS_FLAG:-Auto-detected}"
 echo "Expected cells: ${EXPECTED_CELLS_FLAG:-Auto-detected}"
 
 # Construct command
-CELLBENDER_CMD=("cellbender remove-background"
+CELLBENDER_CMD=("cellbender" "remove-background"
   "--input=$CELLRANGER_DIR/raw_feature_bc_matrix.h5"
   "--output=$OUTPUT_DIR/${SAMPLE_ID}_${USER}_$(date +%Y%m%d).h5"
 )

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -64,6 +64,7 @@ cellranger count \
     --sample="$SAMPLE_ID" \
     --localcores="$CPU" \
     --localmem="$(($MEM / 1000))" \
+    --disable-tenx-assistant \
     $BAM_FLAG
 
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -32,10 +32,13 @@ BAM_FLAG=""  # Default to generating BAM files
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 
 # Handle optional --no-bam flag (disables BAM file generation)
-if [ "$7" == "--no-bam" ]; then
+if [ "$7" == "--no-bam" ] && [ "$VERSION" == "7.0.2" ]; then
   BAM_FLAG="--no-bam"
+elif [ "$7" == "--no-bam" ] && [ "$VERSION" == "9.0.1" ]; then
+  BAM_FLAG="--create-bam false"
+elif [ "$BAM_FLAG" == "" ] && [ "$VERSION" == "9.0.1" ]; then
+  BAM_FLAG="--create-bam true"
 fi
-
 # Load Cell Ranger ARC module (make sure the version is correct)
 if ! module load cellgen/cellranger/"$VERSION"; then
   echo "Failed to load Cell Ranger version $VERSION" >&2

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -64,7 +64,6 @@ cellranger count \
     --sample="$SAMPLE_ID" \
     --localcores="$CPU" \
     --localmem="$(($MEM / 1000))" \
-    --disable-tenx-assistant \
     $BAM_FLAG
 
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -32,7 +32,7 @@ BAM_FLAG=""  # Default to generating BAM files
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 
 # Handle optional --no-bam flag (disables BAM file generation)
-if [ "$7" == "--no-bam" ] && [ "$VERSION" == "7.0.2" ]; then
+if [ "$7" == "--no-bam" ] && [ "$VERSION" -lt "9.0.1" ]; then
   BAM_FLAG="--no-bam"
 elif [ "$7" == "--no-bam" ] && [ "$VERSION" == "9.0.1" ]; then
   BAM_FLAG="--create-bam false"

--- a/bin/cellranger/cellranger_count.sh
+++ b/bin/cellranger/cellranger_count.sh
@@ -31,14 +31,17 @@ MEM="$6"
 BAM_FLAG=""  # Default to generating BAM files
 REF="/software/cellgen/cellgeni/refdata_10x/refdata-gex-GRCh38-2024-A"
 
+INT_VERSION=$(echo "$VERSION" | tr -d '.')
+
 # Handle optional --no-bam flag (disables BAM file generation)
-if [ "$7" == "--no-bam" ] && [ "$VERSION" -lt "9.0.1" ]; then
+if [ "$7" == "--no-bam" ] && [ $INT_VERSION -lt 901 ]; then
   BAM_FLAG="--no-bam"
-elif [ "$7" == "--no-bam" ] && [ "$VERSION" == "9.0.1" ]; then
+elif [ "$7" == "--no-bam" ] && [ $INT_VERSION -eq 901 ]; then
   BAM_FLAG="--create-bam false"
-elif [ "$BAM_FLAG" == "" ] && [ "$VERSION" == "9.0.1" ]; then
+elif [ -z "$BAM_FLAG" ] && [ $INT_VERSION -eq 901 ]; then
   BAM_FLAG="--create-bam true"
 fi
+
 # Load Cell Ranger ARC module (make sure the version is correct)
 if ! module load cellgen/cellranger/"$VERSION"; then
   echo "Failed to load Cell Ranger version $VERSION" >&2


### PR DESCRIPTION
# Description

`9.0.1` cellranger requires alternative flag usage for bam file generation. rather than the inclusion of `--no-bam` flag, there is `--create-bam` with the addition of a boolean value (`True/False`). main changes were made to cellranger_count.sh and added logic for if version` 9.0.1` is defined, but as of now the default version is defined as `7.2.0` (seen in line 32 of `cellranger_count.py`)

Fixes #161 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
