### PR TITLE
Feat/samplewise cellbender params

### DIFF
--- a/bin/cellbender/cellbender.sh
+++ b/bin/cellbender/cellbender.sh
@@ -82,7 +82,7 @@ echo "Total droplets: ${TOTAL_DROPLETS_FLAG:-Auto-detected}"
 echo "Expected cells: ${EXPECTED_CELLS_FLAG:-Auto-detected}"
 
 # Construct command
-CELLBENDER_CMD=("cellbender remove-background"
+CELLBENDER_CMD=("cellbender" "remove-background"
   "--input=$CELLRANGER_DIR/raw_feature_bc_matrix.h5"
   "--output=$OUTPUT_DIR/${SAMPLE_ID}_${USER}_$(date +%Y%m%d).h5"
 )

--- a/solosis/commands/scrna/cellbender.py
+++ b/solosis/commands/scrna/cellbender.py
@@ -109,10 +109,18 @@ def cmd(
             # Add optional arguments if specified
             if gpu:
                 command += " --gpu"
-            if total_droplets_included is not None and total_droplets_included != 0:
-                command += f" --total-droplets-included {total_droplets_included}"
-            if expected_cells is not None and expected_cells != 0:
-                command += f" --expected-cells {expected_cells}"
+            td = sample.get("total_droplets_included")
+            if td is None and total_droplets_included not in (None, False, 0):
+                td = total_droplets_included
+            if td is not None:
+                command += f" --total-droplets-included {td}"
+
+            # Same logic for expected_cells
+            ec = sample.get("expected_cells")
+            if ec is None and expected_cells not in (None, False, 0):
+                ec = expected_cells
+            if ec is not None:
+                command += f" --expected-cells {ec}"
             tmpfile.write(command + "\n")
 
     submit_lsf_job_array(

--- a/solosis/utils/lsf_utils.py
+++ b/solosis/utils/lsf_utils.py
@@ -113,7 +113,7 @@ def submit_lsf_job_array(
         gpumodel = "NVIDIAA100_SXM4_80GB"
         gpu_options = f'#BSUB -gpu "mode=shared:j_exclusive=no:gmem={gpumem}:num={gpunum}:gmodel={gpumodel}"'
         cpu = 4
-        mem = 16000
+        mem = 32000
 
     # Construct the LSF job submission script
     lsf_script = f"""#!/bin/bash


### PR DESCRIPTION
# Description

defining samplewise values for `expected-cells` and `total-droplets-included` within samplefile. Otherwise version 0.3.0 (is the default in solosis) will auto-detect values for these params based on the cellranger outs that you provide.

Fixes #113 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [x] All tests pass (eg. `pytest`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
