### PR TITLE
Bugfix/merge h5ad cmd and fixing conda env for scanpy cmd

### DIFF
--- a/bin/scrna/merge-h5ad/lg28-submit.sh
+++ b/bin/scrna/merge-h5ad/lg28-submit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# scanpy/submit.sh - Run merge-h5ad notebook for a given list of samples
+
+# REQUIREMENTS- running `scanpy` cmd first.
+
+# Usage:
+#   ./submit.sh <sample_id> <output_dir> <cellranger_dir> <version> <cpu> <mem> <time> [--sample_basedir <path>] 
+#
+# Parameters:
+#   <sample_id>         - Sample ID to process.
+#   <output_dir>        - Path to store scanpy output.
+#   <fastq_dir>         - Path to Cell Ranger outputs.
+#   <cpu>               - Number of CPU cores.
+#   <mem>               - Memory in MB.
+#   <time>              - Time allocated to LSF job.
+#   --sample_basedir <path>    - Optional flag to store scanpy outputs in an alternative location to <output_dir> .
+
+set -e # Exit immediately if a command fails

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -34,8 +34,10 @@ CPU="$4"
 MEM="$5"
 TIME="$6"
 # Initialize optional flags
-sample_basedir="/lustre/scratch124/cellgen/haniffa/data/samples"  # Default to use <outout_dir>
 
+#### hardcoded for now ####
+sample_basedir="/lustre/scratch124/cellgen/haniffa/data/samples"  # Default to use <outout_dir>
+solosis_dir="/nfs/users/nfs_l/lg28/repos/solosis"
 ## will need to add conditional statemnt from replacing <output_dir> with --sample_basedir
 
 echo "Arguments received: $@"
@@ -51,7 +53,7 @@ echo "Using $CPU CPU cores and $(($MEM / 1000)) GB memory"
 
 # run the papermill command
 cmd="conda activate $conda_env &&  \
-    papermill $solosis_dir/../../../notebooks/sc_base1.ipynb \
+    papermill $solosis_dir/notebooks/sc_base1.ipynb \
     $OUTPUT_DIR/${SAMPLE_ID}_${SAMPLE_ID}.ipynb  \
     -p samples_database '${sample_basedir}' \
     -p sample_name $SAMPLE_ID \

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -34,7 +34,7 @@ CPU="$5"
 MEM="$6"
 TIME="$7"
 # Initialize optional flags
-sample_basedir="/lustre/scratch124/cellgen/haniffa/sample_data/"  # Default to use <outout_dir>
+sample_basedir="/lustre/scratch124/cellgen/haniffa/data/samples"  # Default to use <outout_dir>
 
 ## will need to add conditional statemnt from replacing <output_dir> with --sample_basedir
 #

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -1,73 +1,66 @@
 #!/bin/bash
+# scanpy/submit.sh - Run Scanpy notebook for a given sample
 
-export LSB_DEFAULT_USERGROUP=team298
+# REQUIREMENTS- running `iget-cellranger` cmd first.
+
+# Usage:
+#   ./submit.sh <sample_id> <output_dir> <cellranger_dir> <version> <cpu> <mem> <time> [--sample_basedir <path>] 
+#
+# Parameters:
+#   <sample_id>         - Sample ID to process.
+#   <output_dir>        - Path to store scanpy output.
+#   <fastq_dir>         - Path to Cell Ranger outputs.
+#   <cpu>               - Number of CPU cores.
+#   <mem>               - Memory in MB.
+#   <time>              - Time allocated to LSF job.
+#   --sample_basedir <path>    - Optional flag to store scanpy outputs in an alternative location to <output_dir> .
+
+set -e # Exit immediately if a command fails
+
 conda_env="/software/cellgen/team298/shared/envs/hlb-conda/rna"
-if [ $# -ne 2 ]; then
-    echo "$0 samples_database sample_sheet.tsv"
-    echo "This is a follow up of irods/pull-processed. If you have not run it, do so"
-    echo "samples_database: Folder where you have all sample cellranger data. Ideally - /lustre/scratch124/cellgen/haniffa/data/samples"
-    echo "sample_name: Folder name of sample that contains the processed_sanger folder"
-    exit 0
+
+# Check if at least 7 arguments are provided
+if [ "$#" -lt 7 ]; then
+  echo "Usage: $0 <sample_id> <output_dir> <cellranger_dir> <version> <cpu> <mem> <time> [--sample_basedir] " >&2
+  exit 1
 fi
 
-samples_database=$1
-shift
-sample_tsv=$1
-shift
+# Assign command-line arguments to variables
+SAMPLE_ID="$1"
+OUTPUT_DIR="$2"
+CELLRANGER_DIR="$3"
+VERSION="$4"
+CPU="$5"
+MEM="$6"
+TIME="$7"
+# Initialize optional flags
+sample_basedir="/lustre/scratch124/cellgen/haniffa/sample_data/"  # Default to use <outout_dir>
 
-#mkdir -p pap
+## will need to add conditional statemnt from replacing <output_dir> with --sample_basedir
+#
+#
+##
 
-mem=50000
-target_dir=$(pwd) # This is obtained by module load hl
-cwd=$(pwd)
-run_token=$RUN_TOKEN
-ofile="rna_scanpy_$run_token.cmds"
-rm -f "$ofile"
-HL_HIST_FOLDER="$cwd/.solosis"
+echo "Arguments received: $@"
 
-declare -i i=0
-while read line; do
-    i+=1
-    if [ $(echo "$line" | grep -c -i Sample) -ne 1 ]; then
-        sample_id=$(echo "$line" | awk ' { print $1 } ')
-        sample_name=$(echo "$line" | awk ' { print $2 } ')
-        cellranger_folder=$(echo "$line" | awk ' { print $NF } ')
-        cellranger_folder=$(basename $cellranger_folder)
+# Ensure output directory exists and create it if not
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
 
-        #sample_name="${sample_id}_${sanger_id}"
-        #sample_folder="$samples_database/${sample_id}_${sanger_id}/processed_sanger/"
-        #outpt_folder="$samples_database/${sample_name}/rna_scanpy/"
-        outpt_folder="$cwd/rna_scanpy/"
-        mkdir -p "$outpt_folder"
-        echo "($i) [Info] $sample_name will be processed in $outpt_folder"
-        echo "$solosis_dir"
-        #="papermill $solosis_dir/../../../notebooks/sc_base1.ipynb $outpt_folder/$sample_name.ipynb  -p samples_database '${samples_database}' -p sample_name $sample_name -k python3  --log-output"
-        cmd="conda activate $conda_env &&  papermill $solosis_dir/../../../notebooks/sc_base1.ipynb $outpt_folder/${sample_name}_${sample_id}.ipynb  -p samples_database '${samples_database}' -p sample_name $sample_name -p sample_id $sample_id -p cellranger_folder cellranger/$cellranger_folder --log-output"
-        echo "$cmd" >>"$ofile"
-    fi
-done <"$sample_tsv"
+echo "Running scanpy notebook for sample: $SAMPLE_ID"
+echo "Output directory: $OUTPUT_DIR"
+echo "cellranger directory: $CELLRANGER_DIR"
+echo "Using $CPU CPU cores and $(($MEM / 1000)) GB memory"
 
-if [ ! -f "$ofile" ]; then
-    echo "Looks like nothing needs to be done"
-    echo "Exiting cleanly..."
-    exit 0
-fi
+# run the papermill command
+cmd="conda activate $conda_env &&  \
+    papermill $solosis_dir/../../../notebooks/sc_base1.ipynb \
+    $OUTPUT_DIR/${SAMPLE_ID}_${SAMPLE_ID}.ipynb  \
+    -p samples_database '${sample_basedir}' \
+    -p sample_name $SAMPLE_ID \
+    -p sample_id $SAMPLE_ID \
+    -p cellranger_folder cellranger/${CELLRANGER_DIR##*/} \
+    --log-output"
 
-total_jobs=$(cat "$ofile" | wc -l)
-bsub_id="rna_scanpy_${run_token}"
-lsf_folder="$HL_HIST_FOLDER/lsf"
-mkdir -p "$lsf_folder"
-cat >"$bsub_id".bsub <<EOF
-#!/bin/bash
-#BSUB -J ${bsub_id}_[1-$total_jobs]%20
-#BSUB -o $lsf_folder/${bsub_id}_%I.out
-#BSUB -e $lsf_folder/${bsub_id}_%I.err
-#BSUB -M $mem
-#BSUB -R "select[mem>$mem] rusage[mem=$mem]"
-conda activate $conda_env
-COMMAND=\$(sed -n "\${LSB_JOBINDEX}p" $ofile) 
-eval \$COMMAND
-EOF
-
-echo "[Info] batch job submitted. check using 'bjobs -w' command"
-bsub <"${bsub_id}".bsub
+chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
+echo "Scanpy notebook completed for sample: $SAMPLE_ID"

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -58,5 +58,9 @@ cmd="conda activate $conda_env &&  \
     -p cellranger_folder cellranger/${CELLRANGER_DIR##*/} \
     --log-output"
 
+echo "Executing papermill command:"
+echo "$cmd"
+eval "$cmd"
+
 chmod -R g+w "$OUTPUT_DIR" >/dev/null 2>&1 || true
 echo "Scanpy notebook completed for sample: $SAMPLE_ID"

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -21,7 +21,7 @@ conda_env="/software/cellgen/team298/shared/envs/hlb-conda/rna"
 
 # Check if at least 7 arguments are provided
 if [ "$#" -lt 7 ]; then
-  echo "Usage: $0 <sample_id> <output_dir> <cellranger_dir> <version> <cpu> <mem> <time> [--sample_basedir] " >&2
+  echo "Usage: $0 <sample_id> <output_dir> <cellranger_dir> <cpu> <mem> <time> [--sample_basedir] " >&2
   exit 1
 fi
 
@@ -29,17 +29,25 @@ fi
 SAMPLE_ID="$1"
 OUTPUT_DIR="$2"
 CELLRANGER_DIR="$3"
-VERSION="$4"
-CPU="$5"
-MEM="$6"
-TIME="$7"
+CPU="$4"
+MEM="$5"
+TIME="$6"
 # Initialize optional flags
 sample_basedir="/lustre/scratch124/cellgen/haniffa/data/samples"  # Default to use <outout_dir>
 
 ## will need to add conditional statemnt from replacing <output_dir> with --sample_basedir
-#
-#
-##
+# Parse optional flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sample_basedir)
+      sample_basedir="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
 
 echo "Arguments received: $@"
 

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -17,6 +17,7 @@
 
 set -e # Exit immediately if a command fails
 
+module load cellgen/conda
 conda_env="/software/cellgen/team298/shared/envs/hlb-conda/rna"
 
 # Check if at least 7 arguments are provided

--- a/bin/scrna/scanpy/submit.sh
+++ b/bin/scrna/scanpy/submit.sh
@@ -20,7 +20,7 @@ set -e # Exit immediately if a command fails
 conda_env="/software/cellgen/team298/shared/envs/hlb-conda/rna"
 
 # Check if at least 7 arguments are provided
-if [ "$#" -lt 7 ]; then
+if [ "$#" -lt 6 ]; then
   echo "Usage: $0 <sample_id> <output_dir> <cellranger_dir> <cpu> <mem> <time> [--sample_basedir] " >&2
   exit 1
 fi
@@ -36,18 +36,6 @@ TIME="$6"
 sample_basedir="/lustre/scratch124/cellgen/haniffa/data/samples"  # Default to use <outout_dir>
 
 ## will need to add conditional statemnt from replacing <output_dir> with --sample_basedir
-# Parse optional flags
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --sample_basedir)
-      sample_basedir="$2"
-      shift 2
-      ;;
-    *)
-      shift
-      ;;
-  esac
-done
 
 echo "Arguments received: $@"
 

--- a/bin/scrna/scanpy/vm11_submit.sh
+++ b/bin/scrna/scanpy/vm11_submit.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+export LSB_DEFAULT_USERGROUP=team298
+conda_env="/software/cellgen/team298/shared/envs/hlb-conda/rna"
+if [ $# -ne 2 ]; then
+    echo "$0 samples_database sample_sheet.tsv"
+    echo "This is a follow up of irods/pull-processed. If you have not run it, do so"
+    echo "samples_database: Folder where you have all sample cellranger data. Ideally - /lustre/scratch124/cellgen/haniffa/data/samples"
+    echo "sample_name: Folder name of sample that contains the processed_sanger folder"
+    exit 0
+fi
+
+samples_database=$1
+shift
+sample_tsv=$1
+shift
+
+#mkdir -p pap
+
+mem=50000
+target_dir=$(pwd) # This is obtained by module load hl
+cwd=$(pwd)
+run_token=$RUN_TOKEN
+ofile="rna_scanpy_$run_token.cmds"
+rm -f "$ofile"
+HL_HIST_FOLDER="$cwd/.solosis"
+
+declare -i i=0
+while read line; do
+    i+=1
+    if [ $(echo "$line" | grep -c -i Sample) -ne 1 ]; then
+        sample_id=$(echo "$line" | awk ' { print $1 } ')
+        sample_name=$(echo "$line" | awk ' { print $2 } ')
+        cellranger_folder=$(echo "$line" | awk ' { print $NF } ')
+        cellranger_folder=$(basename $cellranger_folder)
+
+        #sample_name="${sample_id}_${sanger_id}"
+        #sample_folder="$samples_database/${sample_id}_${sanger_id}/processed_sanger/"
+        #outpt_folder="$samples_database/${sample_name}/rna_scanpy/"
+        outpt_folder="$cwd/rna_scanpy/"
+        mkdir -p "$outpt_folder"
+        echo "($i) [Info] $sample_name will be processed in $outpt_folder"
+        echo "$solosis_dir"
+        #="papermill $solosis_dir/../../../notebooks/sc_base1.ipynb $outpt_folder/$sample_name.ipynb  -p samples_database '${samples_database}' -p sample_name $sample_name -k python3  --log-output"
+        cmd="conda activate $conda_env &&  papermill $solosis_dir/../../../notebooks/sc_base1.ipynb $outpt_folder/${sample_name}_${sample_id}.ipynb  -p samples_database '${samples_database}' -p sample_name $sample_name -p sample_id $sample_id -p cellranger_folder cellranger/$cellranger_folder --log-output"
+        echo "$cmd" >>"$ofile"
+    fi
+done <"$sample_tsv"
+
+if [ ! -f "$ofile" ]; then
+    echo "Looks like nothing needs to be done"
+    echo "Exiting cleanly..."
+    exit 0
+fi
+
+total_jobs=$(cat "$ofile" | wc -l)
+bsub_id="rna_scanpy_${run_token}"
+lsf_folder="$HL_HIST_FOLDER/lsf"
+mkdir -p "$lsf_folder"
+cat >"$bsub_id".bsub <<EOF
+#!/bin/bash
+#BSUB -J ${bsub_id}_[1-$total_jobs]%20
+#BSUB -o $lsf_folder/${bsub_id}_%I.out
+#BSUB -e $lsf_folder/${bsub_id}_%I.err
+#BSUB -M $mem
+#BSUB -R "select[mem>$mem] rusage[mem=$mem]"
+conda activate $conda_env
+COMMAND=\$(sed -n "\${LSB_JOBINDEX}p" $ofile) 
+eval \$COMMAND
+EOF
+
+echo "[Info] batch job submitted. check using 'bjobs -w' command"
+bsub <"${bsub_id}".bsub

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -102,12 +102,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "strange-weekend",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampletable = pd.read_csv(sample_table, sep=\"\\s+\", header=None, index_col=None)"
+    "sampletable = pd.read_csv(sample_table, sep=\"\\s+\", header=None, index_col=None)\n",
+    "sampletable.columns = sampletable.columns.str.strip().str.lower()"
    ]
   },
   {

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -615,7 +615,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.write_h5ad(output_dir, merged_filename)"
+    "output_path = os.path.join(output_dir, merged_filename)\n",
+    "adata.write_h5ad(output_path)"
    ]
   },
   {

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -208,8 +208,7 @@
    "source": [
     "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
     "# making output director for merged object\n",
-    "output_dir = os.path.join(samples_database, \"merged_objects\")\n",
-    "os.makedirs(output_dir, exist_ok=True)"
+    "output_dir = os.path.join(samples_database, \"merged_objects\")\n"
    ]
   },
   {

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -206,6 +206,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
     "# making obj path to adata objects in lustre\n",
     "adata_dir = os.path.join(samples_database, sample_id, \"scanpy\")\n",
     "os.makedirs(adata_dir, exist_ok=True)\n",

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -201,19 +201,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
+   "id": "5b5e8f24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
+    "# making obj path to adata objects in lustre\n",
+    "adata_dir = os.path.join(samples_database, sample_id, \"scanpy\")\n",
+    "os.makedirs(adata_dir, exist_ok=True)\n",
+    "# mkaing output director for merged object\n",
+    "output_dir = os.path.join(samples_database, \"merged_objects\")\n",
+    "os.makedirs(output_dir, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "informal-reynolds",
    "metadata": {},
    "outputs": [],
    "source": [
     "x = []\n",
-    "for i in sample_names:\n",
-    "    h5ad = Path(i, \"rna_scanpy\", i + \".h5ad\")\n",
-    "    print(\"Reading file: \", h5ad)\n",
+    "\n",
+    "# Loop over the validated metadata table\n",
+    "for _, row in sampletable.iterrows():\n",
+    "    sample_id = row[\"sample_id\"]\n",
+    "    sanger_id = row[\"sanger_id\"]\n",
+    "\n",
+    "    # Full h5ad path\n",
+    "    h5ad_path = adata_dir / f\"{sample_id}_{sanger_id}.h5ad\"\n",
+    "\n",
+    "    print(\"Reading file:\", h5ad_path)\n",
     "    try:\n",
-    "        x.append(sc.read_h5ad(h5ad))\n",
-    "    except:\n",
-    "        print(\"File not found\")"
+    "        x.append(sc.read_h5ad(h5ad_path))\n",
+    "    except FileNotFoundError:\n",
+    "        print(\"File not found:\", h5ad_path)"
    ]
   },
   {
@@ -571,12 +594,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "id": "olive-painting",
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.write_h5ad(merged_filename)"
+    "adata.write_h5ad(output_dir, merged_filename)"
    ]
   },
   {
@@ -590,9 +613,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (singlecell)",
+   "display_name": "solosis-sc-env",
    "language": "python",
-   "name": "singlecell"
+   "name": "solosis-sc-env"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -188,13 +188,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "turned-provision",
    "metadata": {},
    "outputs": [],
    "source": [
     "sample_names = list(\n",
-    "    map(lambda x: x[0] + \"_\" + x[1], zip(sampletable[1], sampletable[0]))\n",
+    "    map(lambda x, y: f\"{x}_{y}\", sampletable[\"sample_id\"], sampletable[\"sanger_id\"])\n",
     ")"
    ]
   },

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -207,9 +207,6 @@
    "outputs": [],
    "source": [
     "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
-    "# making obj path to adata objects in lustre\n",
-    "adata_dir = os.path.join(samples_database, sample_id, \"scanpy\")\n",
-    "os.makedirs(adata_dir, exist_ok=True)\n",
     "# making output director for merged object\n",
     "output_dir = os.path.join(samples_database, \"merged_objects\")\n",
     "os.makedirs(output_dir, exist_ok=True)"

--- a/notebooks/rna__merge.ipynb
+++ b/notebooks/rna__merge.ipynb
@@ -107,13 +107,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampletable = pd.read_csv(sample_table, sep=\"\\s+\", header=None, index_col=None)\n",
-    "sampletable.columns = sampletable.columns.str.strip().str.lower()"
+    "# sampletable = pd.read_csv(sample_table, sep=\"\\s+\", header=None, index_col=None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
+   "id": "0460e777",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sampletable = pd.read_csv(metadata)\n",
+    "sampletable.columns = sampletable.columns.str.strip().str.lower()\n",
+    "\n",
+    "sample_names = sampletable[\"sample_id\"] + \"_\" + sampletable[\"sanger_id\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "improved-gospel",
    "metadata": {},
    "outputs": [
@@ -184,19 +196,7 @@
     }
    ],
    "source": [
-    "sampletable"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "turned-provision",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sample_names = list(\n",
-    "    map(lambda x, y: f\"{x}_{y}\", sampletable[\"sample_id\"], sampletable[\"sanger_id\"])\n",
-    ")"
+    "# sampletable"
    ]
   },
   {
@@ -206,13 +206,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
     "# making obj path to adata objects in lustre\n",
     "adata_dir = os.path.join(samples_database, sample_id, \"scanpy\")\n",
     "os.makedirs(adata_dir, exist_ok=True)\n",
-    "# mkaing output director for merged object\n",
+    "# making output director for merged object\n",
     "output_dir = os.path.join(samples_database, \"merged_objects\")\n",
     "os.makedirs(output_dir, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "turned-provision",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sample_names = list(\n",
+    "#    map(lambda x, y: f\"{x}_{y}\", sample_id, sample_name)\n",
+    "# )"
    ]
   },
   {
@@ -224,12 +235,15 @@
    "source": [
     "x = []\n",
     "\n",
-    "# Loop over the validated metadata table\n",
     "for _, row in sampletable.iterrows():\n",
     "    sample_id = row[\"sample_id\"]\n",
     "    sanger_id = row[\"sanger_id\"]\n",
     "\n",
-    "    # Full h5ad path\n",
+    "    # Build per-sample adata directory\n",
+    "    adata_dir = Path(samples_database) / sample_id / \"scanpy\"\n",
+    "    os.makedirs(adata_dir, exist_ok=True)\n",
+    "\n",
+    "    # Build h5ad file path\n",
     "    h5ad_path = adata_dir / f\"{sample_id}_{sanger_id}.h5ad\"\n",
     "\n",
     "    print(\"Reading file:\", h5ad_path)\n",
@@ -241,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "convenient-projection",
    "metadata": {},
    "outputs": [
@@ -257,7 +271,11 @@
     }
    ],
    "source": [
-    "adata = an.concat(x, label=\"batch\")"
+    "# Merge into one object if files were found\n",
+    "if x:\n",
+    "    adata = sc.concat(x, label=\"batch\")\n",
+    "else:\n",
+    "    raise ValueError(\"No valid samples found to merge.\")"
    ]
   },
   {

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -962,9 +962,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (singlecell)",
+   "display_name": "solosis_scanpy",
    "language": "python",
-   "name": "singlecell"
+   "name": "solosis-scanpy"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -956,7 +956,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.write_h5ad(os.path.join(outpt_folder, sample_id , \"_\", sample_name + \".h5ad\"))"
+    "adata.write_h5ad(os.path.join(outpt_folder, sample_id  + \"_\" + sample_name + \".h5ad\"))"
    ]
   }
  ],

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -956,7 +956,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.write_h5ad(os.path.join(outpt_folder, sample_name + sample_id + \".h5ad\"))"
+    "adata.write_h5ad(os.path.join(outpt_folder, sample_id , \"_\", sample_name + \".h5ad\"))"
    ]
   }
  ],

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -956,7 +956,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.write_h5ad(os.path.join(outpt_folder, sample_id  + \"_\" + sample_name + \".h5ad\"))"
+    "adata.write_h5ad(os.path.join(outpt_folder, sample_id + \"_\" + sample_name + \".h5ad\"))"
    ]
   }
  ],

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "registered-minneapolis",
    "metadata": {
     "tags": [
@@ -136,7 +136,7 @@
    },
    "outputs": [],
    "source": [
-    "samples_database = \"/lustre/scratch126/cellgen/team298/sample_data/\"\n",
+    "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
     "# sample_n = \"Apr24_chimeroid_d97_03A-BFP_HCA_SkO15052460\"\n",
     "# sample_folder=\"/lustre/scratch126/cellgen/team298/sample_data/BK23-SKI-27-FT-1b_mG_rBCN14655446/processed_sanger\"\n",
     "sample_name = \"BK23-SKI-27-FT-1b_mG\"\n",

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -137,8 +137,6 @@
    "outputs": [],
    "source": [
     "samples_database = \"/lustre/scratch124/cellgen/haniffa/data/samples\"\n",
-    "# sample_n = \"Apr24_chimeroid_d97_03A-BFP_HCA_SkO15052460\"\n",
-    "# sample_folder=\"/lustre/scratch126/cellgen/team298/sample_data/BK23-SKI-27-FT-1b_mG_rBCN14655446/processed_sanger\"\n",
     "sample_name = \"BK23-SKI-27-FT-1b_mG\"\n",
     "sample_id = \"HCA_SkO15052460\"\n",
     "cellranger_folder = \"cellranger-dff\""

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -172,7 +172,7 @@
     "# Read file\n",
     "# outpt_folder = os.path.join(samples_database, \"rna_scanpy\", sample_id)\n",
     "# outpt_folder =  os.path.join(\"test\", sample_name)\n",
-    "outpt_folder = os.path.join(samples_database, \"rna_scanpy\")\n",
+    "outpt_folder = os.path.join(samples_database, sample_id, \"scanpy\")\n",
     "os.makedirs(outpt_folder, exist_ok=True)\n",
     "print(samples_database)\n",
     "print(sample_id)\n",

--- a/notebooks/sc_base1.ipynb
+++ b/notebooks/sc_base1.ipynb
@@ -962,9 +962,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "solosis_scanpy",
+   "display_name": "solosis-sc-env",
    "language": "python",
-   "name": "solosis-scanpy"
+   "name": "solosis-sc-env"
   },
   "language_info": {
    "codemirror_mode": {

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -37,12 +37,12 @@ NOTEBOOK_PATH = os.path.join(base, "notebooks", "rna__merge.ipynb")
 @debug
 @log
 def cmd(
-    samplefile, merged_filename, job_name, mem, cpu, queue, gpu, time, debug, **kwargs
+    metadata, merged_filename, job_name, mem, cpu, queue, gpu, time, debug, **kwargs
 ):
     """
     Submit a job to merge multiple h5ad objects into a single file.
 
-    Input samplefile should have 3 mandatory columns:
+    Input metadata should have 3 mandatory columns:
     1st column: sample_id, 2nd column: sanger_id, 3rd column: cellranger_dir
 
     Make sure to run `solosis-cli sc-rna scanpy --metadata ...` first.
@@ -59,6 +59,10 @@ def cmd(
 
     # Path of the expected output notebook
     scanpy_output = os.path.join(output_dir, f"{sample_id}_{sanger_id}.ipynb")
+
+    samples = process_metadata_file(
+        metadata, required_columns={"sample_id", "cellranger_dir", "sanger_id"}
+    )
 
     valid_samples = []
     for sample in samples:

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -77,6 +77,11 @@ def cmd(
         metadata, required_columns={"sample_id", "cellranger_dir", "sanger_id"}
     )
 
+    # defining output path for notebook
+    output_notebook = os.path.join(
+        sample_basedir, f"merged_objects", f"{merged_filename}.ipynb"
+    )
+
     valid_samples = []
     for sample in samples:
         sample_id = sample["sample_id"]
@@ -125,10 +130,6 @@ def cmd(
             sample_id = sample["sample_id"]
             sanger_id = sample["sanger_id"]
             # Build papermill command
-            output_notebook = os.path.join(
-                sample_basedir, f"merged_objects", f"{merged_filename}.ipynb"
-            )
-
             command = (
                 f"module load cellgen/conda && "
                 f"source activate {conda_env} && "

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -105,7 +105,6 @@ def cmd(
     ) as tmpfile:
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
-        tmpfile.write(command_str + "\n")
         # Build papermill command
         command = (
             f"module load cellgen/conda && "

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -34,10 +34,26 @@ NOTEBOOK_PATH = os.path.join(base, "notebooks", "rna__merge.ipynb")
     default="merge_h5ad",
     help="Optional name for the LSF job. Defaults to merge_h5ad_<uid>.",
 )
+@click.option(
+    "--sample_basedir",
+    required=False,
+    default="/lustre/scratch124/cellgen/haniffa/data/samples",
+    help="Sample database folder",
+)
 @debug
 @log
 def cmd(
-    metadata, merged_filename, job_name, mem, cpu, queue, gpu, time, debug, **kwargs
+    metadata,
+    merged_filename,
+    job_name,
+    sample_basedir,
+    mem,
+    cpu,
+    queue,
+    gpu,
+    time,
+    debug,
+    **kwargs,
 ):
     """
     Submit a job to merge multiple h5ad objects into a single file.
@@ -112,6 +128,7 @@ def cmd(
             f"papermill {NOTEBOOK_PATH} merge_{merged_filename}.ipynb "
             f"-p sample_table {metadata} "
             f"-p merged_filename {merged_filename} "
+            f"-p samples_database '{sample_basedir}' "
             f"-k python3;"
         )
         tmpfile.write(command + "\n")

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -129,7 +129,6 @@ def cmd(
             f"-p sample_table {metadata} "
             f"-p merged_filename {merged_filename} "
             f"-p samples_database '{sample_basedir}' "
-            f"-k python3;"
         )
         tmpfile.write(command + "\n")
 

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -126,7 +126,7 @@ def cmd(
             sanger_id = sample["sanger_id"]
             # Build papermill command
             output_notebook = os.path.join(
-                output_dir, f"merged_objects", f"{merged_filename}.ipynb"
+                sample_basedir, f"merged_objects", f"{merged_filename}.ipynb"
             )
 
             command = (

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -125,10 +125,14 @@ def cmd(
             sample_id = sample["sample_id"]
             sanger_id = sample["sanger_id"]
             # Build papermill command
+            output_notebook = os.path.join(
+                output_dir, f"merged_objects", f"{merged_filename}.ipynb"
+            )
+
             command = (
                 f"module load cellgen/conda && "
                 f"source activate {conda_env} && "
-                f"papermill {NOTEBOOK_PATH} merge_{merged_filename}.ipynb "
+                f"papermill {NOTEBOOK_PATH} {output_notebook} "
                 f'-p metadata "{metadata}" '
                 f'-p merged_filename "{merged_filename}" '
                 f'-p samples_database "{sample_basedir}" '

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -121,16 +121,19 @@ def cmd(
     ) as tmpfile:
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
-        # Build papermill command
-        command = (
-            f"module load cellgen/conda && "
-            f"source activate {conda_env} && "
-            f"papermill {NOTEBOOK_PATH} merge_{merged_filename}.ipynb "
-            f"-p sample_table {metadata} "
-            f"-p merged_filename {merged_filename} "
-            f"-p samples_database '{sample_basedir}' "
-        )
-        tmpfile.write(command + "\n")
+        for sample in valid_samples:
+            sample_id = sample["sample_id"]
+            sanger_id = sample["sanger_id"]
+            # Build papermill command
+            command = (
+                f"module load cellgen/conda && "
+                f"source activate {conda_env} && "
+                f"papermill {NOTEBOOK_PATH} merge_{merged_filename}.ipynb "
+                f'-p metadata "{metadata}" '
+                f'-p merged_filename "{merged_filename}" '
+                f'-p samples_database "{sample_basedir}" '
+            )
+            tmpfile.write(command + "\n")
 
     submit_lsf_job_array(
         command_file=tmpfile.name,

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -57,9 +57,6 @@ def cmd(
     job_name = execution_uid if job_name == "default" else f"{job_name}_{execution_uid}"
     logger.debug(f"Job name: {job_name}")
 
-    # Path of the expected output notebook
-    scanpy_output = os.path.join(output_dir, f"{sample_id}_{sanger_id}.ipynb")
-
     samples = process_metadata_file(
         metadata, required_columns={"sample_id", "cellranger_dir", "sanger_id"}
     )
@@ -76,8 +73,10 @@ def cmd(
 
         sanger_id = sample.get("sanger_id") or sample["sample_id"]
         output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
-        os.makedirs(output_dir, exist_ok=True)
+        # Path of the expected output notebook
+        scanpy_output = os.path.join(output_dir, f"{sample_id}_{sanger_id}.ipynb")
 
+        os.makedirs(output_dir, exist_ok=True)
         # Path of the expected output notebook
         scanpy_notebook = os.path.join(output_dir, f"{sample_id}_{sanger_id}.ipynb")
 

--- a/solosis/commands/scrna/merge_h5ad.py
+++ b/solosis/commands/scrna/merge_h5ad.py
@@ -132,6 +132,7 @@ def cmd(
                 f'-p metadata "{metadata}" '
                 f'-p merged_filename "{merged_filename}" '
                 f'-p samples_database "{sample_basedir}" '
+                f"-k solosis-sc-env"
             )
             tmpfile.write(command + "\n")
 

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -88,7 +88,7 @@ def cmd(
             command = (
                 f"module load cellgen/conda &&"
                 f"source activate {conda_env} &&"
-                f"papermill ../../notebooks/sc_base1.ipynb "
+                f"papermill solosis/notebooks/sc_base1.ipynb "
                 f"{output_dir}/{sample_id}_{sample_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
                 f"-p sample_name '{sample_id}' "

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -4,7 +4,7 @@ import tempfile
 
 import click
 
-from solosis.utils.input_utils import collect_samples
+from solosis.utils.input_utils import process_metadata_file
 from solosis.utils.logging_utils import debug, log
 from solosis.utils.lsf_utils import lsf_job, submit_lsf_job_array
 from solosis.utils.state import execution_uid, logger

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -49,7 +49,7 @@ def cmd(
     Submit Scanpy workflow for scRNA-seq data as a job on the compute farm.
 
     Input samplefile should have 3 mandatory columns:
-    1st column: sanger_id, 2nd column: sample_name, 3rd column: irods path
+    1st column: sample_id, 2nd column: sanger_id, 3rd column: irods path
     """
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -14,7 +14,7 @@ from solosis.utils.state import execution_uid, logger
 
 @lsf_job(mem=64000, cpu=4, queue="normal", time="12:00")
 @click.command("scanpy")
-@click.option("--samplefile", required=True, help="Sample file text file")
+@click.option("--metadata", required=True, help="Sample file text file")
 @click.option(
     "--sample_basedir",
     required=False,
@@ -31,7 +31,7 @@ from solosis.utils.state import execution_uid, logger
 @debug
 @log
 def cmd(
-    samplefile, sample_basedir, job_name, mem, cpu, queue, gpu, time, debug, **kwargs
+    metadata, sample_basedir, job_name, mem, cpu, queue, gpu, time, debug, **kwargs
 ):
     """
     Submit Scanpy workflow for scRNA-seq data as a job on the compute farm.

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -12,7 +12,7 @@ from solosis.utils.state import execution_uid, logger
 ##maybe add in validation with `from solosis.utils.input_utils import collect_samples`
 
 ########
-conda_env = "/software/cellgen/team298/shared/envs/solosis-scanpy"
+conda_env = "/software/cellgen/team298/shared/envs/solosis-sc-env"
 
 # SOLOSIS_DIR = os.getenv("SOLOSIS_BASE") ## wouldn't work without the solosis module loaded
 

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -62,19 +62,15 @@ def cmd(
         )
         os.makedirs(output_dir, exist_ok=True)
 
-        # Validate irods path
-        if validate_cellranger_dir(sample_id, cellranger_dir):
-            valid_samples.append(
-                {
-                    "sample_id": sample_id,
-                    "cellranger_dir": cellranger_dir,
-                    "output_dir": output_dir,
-                }
-            )
-        else:
-            logger.warning(
-                f"Unable to validate cellranger path {sample['cellranger_dir']} for sample {sample['sample_id']}. Run `iget-cellranger` cmd before re-trying."
-            )
+        # will need to validate cellranger dir
+
+        valid_samples.append(
+            {
+                "sample_id": sample_id,
+                "cellranger_dir": cellranger_dir,
+                "output_dir": output_dir,
+            }
+        )
 
     if not valid_samples:
         logger.error(f"No valid samples found. Exiting")

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -69,6 +69,12 @@ def cmd(
     for sample in samples:
         sample_id = sample["sample_id"]
         cellranger_dir = sample["cellranger_dir"]
+        if not os.path.exists(cellranger_dir):
+            logger.error(
+                f"Cellranger path does not exist: {cellranger_dir} for sample: {sample_id}. Skipping."
+            )
+            continue  # skip this sample entirely
+
         sanger_id = sample.get("sanger_id") or sample["sample_id"]
         output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
         os.makedirs(output_dir, exist_ok=True)

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -14,7 +14,13 @@ from solosis.utils.state import execution_uid, logger
 ########
 conda_env = "/software/cellgen/team298/shared/envs/hlb-conda/rna"
 
-SOLOSIS_DIR = os.getenv("SOLOSIS_BASE")
+# SOLOSIS_DIR = os.getenv("SOLOSIS_BASE") ## wouldn't work without the solosis module loaded
+
+# found this potential solution
+base = os.getenv(
+    "SOLOSIS_BASE", os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+)
+NOTEBOOK_PATH = os.path.join(base, "notebooks", "sc_base1.ipynb")
 ########
 
 
@@ -90,7 +96,7 @@ def cmd(
             command = (
                 f"module load cellgen/conda &&"
                 f"source activate {conda_env} &&"
-                f"papermill {SOLOSIS_DIR}/notebooks/sc_base1.ipynb "
+                f"papermill {NOTEBOOK_PATH} "
                 f"{output_dir}/{sample_id}_{sample_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
                 f"-p sample_name '{sample_id}' "

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -13,6 +13,8 @@ from solosis.utils.state import execution_uid, logger
 
 ########
 conda_env = "/software/cellgen/team298/shared/envs/hlb-conda/rna"
+
+SOLOSIS_DIR = os.getenv("SOLOSIS_BASE")
 ########
 
 
@@ -88,7 +90,7 @@ def cmd(
             command = (
                 f"module load cellgen/conda &&"
                 f"source activate {conda_env} &&"
-                f"papermill solosis/notebooks/sc_base1.ipynb "
+                f"papermill {SOLOSIS_DIR}/notebooks/sc_base1.ipynb "
                 f"{output_dir}/{sample_id}_{sample_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
                 f"-p sample_name '{sample_id}' "

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -88,11 +88,11 @@ def cmd(
             command = (
                 f"source activate {conda_env} &&"
                 f"papermill ../../notebooks/sc_base1.ipynb "
-                f"{output_dir}/{samples[sample_id]}_{samples[sample_id]}.ipynb "
+                f"{output_dir}/{sample_id}_{sample_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
-                f"-p sample_name '{sample[sample_id]}' "
-                f"-p sample_id '{sample[sample_id]}' "
-                f"-p cellranger_folder '{sample[cellranger_dir]}' "
+                f"-p sample_name '{sample_id}' "
+                f"-p sample_id '{sample_id}' "
+                f"-p cellranger_folder '{cellranger_dir}' "
                 "--log-output"
             )
             tmpfile.write(command + "\n")

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -26,7 +26,7 @@ NOTEBOOK_PATH = os.path.join(base, "notebooks", "sc_base1.ipynb")
 
 @lsf_job(mem=64000, cpu=4, queue="normal", time="12:00")
 @click.command("scanpy")
-@click.option("--metadata", required=True, help="Sample file text file")
+@click.option("--metadata", required=True, help="metadata csv file")
 @click.option(
     "--sample_basedir",
     required=False,
@@ -49,7 +49,7 @@ def cmd(
     Submit Scanpy workflow for scRNA-seq data as a job on the compute farm.
 
     Input samplefile should have 3 mandatory columns:
-    1st column: sample_id, 2nd column: sanger_id, 3rd column: irods path
+    1st column: sample_id, 2nd column: sanger_id, 3rd column: cellranger_dir
     """
     if debug:
         logger.setLevel(logging.DEBUG)
@@ -121,8 +121,8 @@ def cmd(
                 f"papermill {NOTEBOOK_PATH} "
                 f"{output_dir}/{sample_id}_{sanger_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
-                f"-p sample_name '{sample_id}' "
-                f"-p sanger_id '{sanger_id}' "
+                f"-p sample_name '{sanger_id}' "
+                f"-p sample_id '{sample_id}' "
                 f"-p cellranger_folder '{cellranger_dir}' "
                 "--log-output"
             )

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -86,8 +86,7 @@ def cmd(
         for sample in valid_samples:
             # Build papermill command
             command = (
-                f"module load cellgen/conda"
-                f"source activate {conda_env}"
+                f"source activate {conda_env} &&"
                 f"papermill ../../notebooks/sc_base1.ipynb "
                 f"{output_dir}/{samples[sample_id]}_{samples[sample_id]}.ipynb "
                 f"-p samples_database '{sample_basedir}' "

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -103,6 +103,11 @@ def cmd(
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
         for sample in valid_samples:
+            sample_id = sample["sample_id"]
+            sanger_id = sample["sanger_id"]
+            cellranger_dir = sample["cellranger_dir"]
+            output_dir = sample["output_dir"]
+
             # Build papermill command
             command = (
                 f"module load cellgen/conda && "

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -74,7 +74,7 @@ def cmd(
         os.makedirs(output_dir, exist_ok=True)
 
         # Path of the expected output notebook
-        scanpy_output = os.path.join(output_dir, f"{sample_id}_{sample_id}.ipynb")
+        scanpy_output = os.path.join(output_dir, f"{sample_id}_{sanger_id}.ipynb")
 
         if os.path.exists(scanpy_output):
             logger.warning(

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -90,7 +90,7 @@ def cmd(
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
         for sample in valid_samples:
-            command = f"{scanpy_shell_script} {sample['sample_id']} {sample['output_dir']} {sample['cellranger_dir']} {version} {cpu} {mem}"
+            command = f"{scanpy_shell_script} {sample['sample_id']} {sample['output_dir']} {sample['cellranger_dir']} {cpu} {mem}"
             if sample_basedir:
                 command += f" --sample_basedir {sample_basedir}"
             tmpfile.write(command + "\n")

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -62,7 +62,7 @@ def cmd(
     logger.debug(f"Job name: {job_name}")
 
     samples = process_metadata_file(
-        metadata, required_columns={"sample_id", "cellranger_dir"}
+        metadata, required_columns={"sample_id", "cellranger_dir", "sanger_id"}
     )
 
     valid_samples = []

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -69,7 +69,9 @@ def cmd(
     for sample in samples:
         sample_id = sample["sample_id"]
         cellranger_dir = sample["cellranger_dir"]
-        sanger_id = sample.get("sanger_id", sample_id)
+        sanger_id = sample.get("sanger_id")
+        if not sanger_id:
+            sanger_id = sample_id
         output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
         os.makedirs(output_dir, exist_ok=True)
 

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -18,7 +18,7 @@ from solosis.utils.state import execution_uid, logger
 @click.option(
     "--sample_basedir",
     required=False,
-    default="/lustre/scratch124/cellgen/haniffa/sample_data/",
+    default="/lustre/scratch124/cellgen/haniffa/data/samples",
     help="Sample database folder",
 )
 @click.option(

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -86,6 +86,7 @@ def cmd(
         for sample in valid_samples:
             # Build papermill command
             command = (
+                f"module load cellgen/conda &&"
                 f"source activate {conda_env} &&"
                 f"papermill ../../notebooks/sc_base1.ipynb "
                 f"{output_dir}/{sample_id}_{sample_id}.ipynb "

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -72,6 +72,15 @@ def cmd(
         output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
         os.makedirs(output_dir, exist_ok=True)
 
+        # Path of the expected output notebook
+        scanpy_output = os.path.join(output_dir, f"{sample_id}_{sample_id}.ipynb")
+
+        if os.path.exists(scanpy_output):
+            logger.warning(
+                f"Notebook for {sample_id} already exists at {scanpy_output}. Skipping."
+            )
+            continue  # skip this sample
+
         # will need to validate cellranger dir
 
         valid_samples.append(

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -12,7 +12,7 @@ from solosis.utils.state import execution_uid, logger
 ##maybe add in validation with `from solosis.utils.input_utils import collect_samples`
 
 ########
-conda_env = "/software/cellgen/team298/shared/envs/hlb-conda/rna"
+conda_env = "/software/cellgen/team298/shared/envs/solosis-scanpy"
 
 # SOLOSIS_DIR = os.getenv("SOLOSIS_BASE") ## wouldn't work without the solosis module loaded
 

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -69,9 +69,7 @@ def cmd(
     for sample in samples:
         sample_id = sample["sample_id"]
         cellranger_dir = sample["cellranger_dir"]
-        sanger_id = sample.get("sanger_id")
-        if not sanger_id:
-            sanger_id = sample_id
+        sanger_id = sample.get("sanger_id") or sample["sample_id"]
         output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
         os.makedirs(output_dir, exist_ok=True)
 
@@ -117,8 +115,8 @@ def cmd(
                 f"papermill {NOTEBOOK_PATH} "
                 f"{output_dir}/{sample_id}_{sanger_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
-                f"-p sample_name '{sanger_id}' "
-                f"-p sample_id '{sample_id}' "
+                f"-p sample_name '{sample_id}' "
+                f"-p sanger_id '{sanger_id}' "
                 f"-p cellranger_folder '{cellranger_dir}' "
                 "--log-output"
             )

--- a/solosis/commands/scrna/scanpy.py
+++ b/solosis/commands/scrna/scanpy.py
@@ -69,6 +69,7 @@ def cmd(
     for sample in samples:
         sample_id = sample["sample_id"]
         cellranger_dir = sample["cellranger_dir"]
+        sanger_id = sample.get("sanger_id", sample_id)
         output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), sample_id)
         os.makedirs(output_dir, exist_ok=True)
 
@@ -86,6 +87,7 @@ def cmd(
         valid_samples.append(
             {
                 "sample_id": sample_id,
+                "sanger_id": sanger_id,
                 "cellranger_dir": cellranger_dir,
                 "output_dir": output_dir,
             }
@@ -103,12 +105,12 @@ def cmd(
         for sample in valid_samples:
             # Build papermill command
             command = (
-                f"module load cellgen/conda &&"
-                f"source activate {conda_env} &&"
+                f"module load cellgen/conda && "
+                f"source activate {conda_env} && "
                 f"papermill {NOTEBOOK_PATH} "
-                f"{output_dir}/{sample_id}_{sample_id}.ipynb "
+                f"{output_dir}/{sample_id}_{sanger_id}.ipynb "
                 f"-p samples_database '{sample_basedir}' "
-                f"-p sample_name '{sample_id}' "
+                f"-p sample_name '{sanger_id}' "
                 f"-p sample_id '{sample_id}' "
                 f"-p cellranger_folder '{cellranger_dir}' "
                 "--log-output"


### PR DESCRIPTION
# Description

Both `scanpy` cmd and `merge_h5ad` cmd are working as expected. 

fixed `merge_h5ad` command, it is now merging h5ad objects made by scanpy cmd by using `metadata csv` file, but only really needs `sample_id` and `sanger_id` to run, it just mean that the same `metadata csv` file from `scanpy` command can be used for `merge_h5ad` command too.

Made new conda env and kernel to run the notebooks successfully too. 
```
conda create -p /software/cellgen/team298/shared/envs/solosis-sc-env python=3.10
conda install -c conda-forge scanpy python-igraph leidenalg
conda install pandas
conda install ipykernel
conda install -c conda-forge papermill
python -m ipykernel install --prefix=/software/cellgen/team298/shared/envs/solosis-sc-env --name solosis-sc-env --display-name "solosis-sc-env"
```


Fixes #192 #194 (commits pointing to #193 by accident.. it is meant to be #194)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
