### PR TITLE
Bugfix/iget cellranger sample handling

### DIFF
--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -83,8 +83,8 @@ def cmd(
         os.chmod(tmpfile.name, 0o660)
         for sample in valid_samples:
             command = (
-                f"iget -r {sample[irods_path]} {sample[output_dir]} ; "
-                f"chmod -R g+w {sample[output_dir]} >/dev/null 2>&1 || true"
+                f"iget -r {sample['irods_path']} {sample['output_dir']} ; "
+                f"chmod -R g+w {sample['output_dir']} >/dev/null 2>&1 || true"
             )
             tmpfile.write(command + "\n")
 


### PR DESCRIPTION
# Description

without this, the same sample_id and irods path was submitted per job in the array 
i.e. metadata file
```
sample_id,irods_path
HCA_SkO14542035,/seq/illumina/runs/48/48214/cellranger/cellranger700_count_48214_HCA_SkO14542035_GRCh38-2020-A
HCA_SkO14542036,/seq/illumina/runs/48/48282/cellranger/cellranger700_count_48282_HCA_SkO14542036_GRCh38-2020-A
```
the following command is executed for both samples
```
iget -r /seq/illumina/runs/48/48282/cellranger/cellranger700_count_48282_HCA_SkO14542036_GRCh38-2020-A /lustre/scratch124/cellgen/haniffa/data/samples/HCA_SkO14542036/cellranger
```
this fix ensures both sample ids and respective irods_path are handled as expected.
Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
