### PR TITLE
Add required to --metadata flag of iget-cellranger command 

### DIFF
--- a/solosis/commands/irods/iget_cellranger.py
+++ b/solosis/commands/irods/iget_cellranger.py
@@ -18,6 +18,7 @@ from solosis.utils.state import logger
     "--metadata",
     type=click.Path(exists=True),
     help="Path to a CSV or TSV file containing metadata",
+    required=True,
 )
 @debug
 @log


### PR DESCRIPTION
# Description

add required label to iget-cellranger command flag `--metadata`
now looks like this:
```
$ ./solosis-cli irods iget-cellranger --help
  SOLOSIS    ~  version 0.4.2
INFO: Initialized with execution_uid: cd75dff0-77ed-4468-86d1-4b96e15d20c3
Usage: solosis-cli irods iget-cellranger [OPTIONS]

Options:
  --metadata PATH   Path to a CSV or TSV file containing metadata  [required]
  --debug           Enable debug mode
  --mem INTEGER     Memory limit (in MB)  [default: 4000]
  --cpu INTEGER     Number of CPU cores  [default: 2]
  --queue TEXT      Queue to which the job should be submitted  [default:
                    small]
  --gpu             Request a GPU with default settings
  --gpumem INTEGER  GPU memory limit (in MB)  [default: 6000]
  --gpunum INTEGER  Number of GPUs to request  [default: 1]
  --gpumodel TEXT   GPU model to request. Must be one of:
                    NVIDIAA100_SXM4_80GB, NVIDIAH10080GBHBM3,
                    TeslaV100_SXM2_16GB, TeslaV100_SXM2_32GB  [default:
                    NVIDIAA100_SXM4_80GB]
  --time TEXT       Maximum runtime for the job (e.g. 12:00 for 12 hours)
                    [default: 12:00]
  --help            Show this message and exit.
```

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
