### PR TITLE
Opt/cellranger arc outputdir changes

### DIFF
--- a/solosis/commands/alignment/cellranger_arc_count.py
+++ b/solosis/commands/alignment/cellranger_arc_count.py
@@ -106,9 +106,7 @@ def cmd(
             # Generate ID (name of output directory) by concatenating sorted 'sample' values
             sorted_samples = sorted(df["sample"].dropna().astype(str).tolist())
             library_id = "_".join(sorted_samples)
-            output_dir = os.path.join(
-                os.getenv("TEAM_SAMPLES_DIR"), "cellranger_arc", library_id
-            )
+            output_dir = os.path.join(os.getenv("TEAM_SAMPLES_DIR"), "cellranger_arc")
 
             # Append the validated details
             valid_libraries.append(


### PR DESCRIPTION
# Description

The current output dir for cellranger arc is `data/samples/cellranger_arc/HCA_rFSKI14910886_HCA_rFSKI14910982/HCA_rFSKI14910886_HCA_rFSKI14910982/outs`
I've updated this to be 
`data/samples/cellranger_arc/HCA_rFSKI14910886_HCA_rFSKI14910982/outs`

Fixes #212 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
