### PR TITLE
adding time arg to cellranger_arc_count.py script and bugfix #211

### DIFF
--- a/solosis/commands/alignment/cellranger_arc_count.py
+++ b/solosis/commands/alignment/cellranger_arc_count.py
@@ -138,7 +138,7 @@ def cmd(
         logger.debug(f"Temporary command file created: {tmpfile.name}")
         os.chmod(tmpfile.name, 0o660)
         for library in valid_libraries:
-            command = f"{cellranger_arc_count_path} {library['id']} {library['output_dir']} {library['libraries_path']} {version} {cpu} {mem}"
+            command = f"{cellranger_arc_count_path} {library['id']} {library['output_dir']} {library['libraries_path']} {version} {cpu} {mem} {time}"
             tmpfile.write(command + "\n")
 
     submit_lsf_job_array(


### PR DESCRIPTION
# Description

fixing error..
```
error: Invalid value for '--libraries <CSV>': No such file or directory: '../../oct25_libarc.csv'

For more information try --help
```
Added `{time}` arg `cmd` in `cellranger_arc_count.py` 
but also added absolute path to oct25_libarc.csv to ensure this wasn't causing the error.

## **UPDATE 10/11/25**
using the absolute path for the input metadata file fixed this error.
using relative path:
`./solosis-cli alignment cellranger-arc-count --libraries ../../oct25_libarc.csv`
gave this error:
```
error: Invalid value for '--libraries <CSV>': No such file or directory: '../../oct25_libarc.csv'

For more information try --help
```

using absolute path:
`./solosis-cli alignment cellranger-arc-count --libraries /nfs/users/nfs_l/lg28/oct25_libarc.csv`
no error

Fixes #211 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
